### PR TITLE
PR: Update Module Dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,17 +2,11 @@ module github.com/LumeraProtocol/supernode
 
 go 1.24.0
 
-replace (
-	github.com/LumeraProtocol/lumera => ../lumera
-	github.com/LumeraProtocol/rq-service => ../rq-service/gen
-	github.com/LumeraProtocol/supernode => .
-)
-
 require (
 	cosmossdk.io/api v0.7.6
-	github.com/LumeraProtocol/dd-service v0.0.0-20250226082440-ebf419254f36
-	github.com/LumeraProtocol/lumera v0.4.1
-	github.com/LumeraProtocol/rq-service v0.0.0-00010101000000-000000000000
+	github.com/LumeraProtocol/dd-service/gen v0.0.0-20250305185425-22977769a449
+	github.com/LumeraProtocol/lumera v0.4.2
+	github.com/LumeraProtocol/rq-service/gen v0.0.0-20250305185258-cf252902b897
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cosmos/btcutil v1.0.5
@@ -178,5 +172,3 @@ require (
 	pgregory.net/rapid v1.1.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/LumeraProtocol/dd-service => ../dd-service/gen

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,12 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/LumeraProtocol/dd-service/gen v0.0.0-20250305185425-22977769a449 h1:VwXwh/bNCNmj8OgIyM+LfqMCqqSGjRtQv983HiYCKcE=
+github.com/LumeraProtocol/dd-service/gen v0.0.0-20250305185425-22977769a449/go.mod h1:/ieXOhfSDyTbcyB1GFmKr4t2b0YGYn0O8ikMNBMnOMA=
+github.com/LumeraProtocol/lumera v0.4.2 h1:yW7mwoYiBCcFLFNs9AgmaLc0DVkir95NGFtR2j/VYsw=
+github.com/LumeraProtocol/lumera v0.4.2/go.mod h1:MRqVY+f8edEBkDvpr4z2nJpglp3Qj1OUvjeWvrvIUSM=
+github.com/LumeraProtocol/rq-service/gen v0.0.0-20250305185258-cf252902b897 h1:sxqhMpcQm8KjDFvhs6yg3Vyv9gt9uxBnfpZRewxAFos=
+github.com/LumeraProtocol/rq-service/gen v0.0.0-20250305185258-cf252902b897/go.mod h1:+b6pn5XADYaATzzaKRZtCeIyYW2845v34gZ8NaPtPgI=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/pkg/dd/client.go
+++ b/pkg/dd/client.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	ddService "github.com/LumeraProtocol/dd-service"
+	ddService "github.com/LumeraProtocol/dd-service/gen"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/dd/image_rareness.go
+++ b/pkg/dd/image_rareness.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ddService "github.com/LumeraProtocol/dd-service"
+	ddService "github.com/LumeraProtocol/dd-service/gen"
 	"github.com/LumeraProtocol/supernode/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/pkg/net"
 )

--- a/pkg/dd/status.go
+++ b/pkg/dd/status.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ddService "github.com/LumeraProtocol/dd-service"
+	ddService "github.com/LumeraProtocol/dd-service/gen"
 	"github.com/LumeraProtocol/supernode/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/pkg/net"
 )

--- a/pkg/lumera/supernode/client.go
+++ b/pkg/lumera/supernode/client.go
@@ -18,7 +18,7 @@ type Client struct {
 
 type Service interface {
 	GetTopSNsByBlockHeight(ctx context.Context, r GetTopSupernodesForBlockRequest) (GetTopSupernodesForBlockResponse, error)
-	GetSupernodeByAddress(ctx context.Context, r GetSupernodeRequest) (SuperNode, error)
+	GetSupernodeByAddress(ctx context.Context, r GetSupernodeRequest) (lumerasn.SuperNode, error)
 }
 
 func NewClient(serverAddr string) (Service, error) {

--- a/pkg/raptorq/client.go
+++ b/pkg/raptorq/client.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"google.golang.org/grpc"
 
-	rq "github.com/LumeraProtocol/rq-service"
+	rq "github.com/LumeraProtocol/rq-service/gen"
 )
 
 type Client struct {

--- a/pkg/raptorq/decode.go
+++ b/pkg/raptorq/decode.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	rq "github.com/LumeraProtocol/rq-service"
+	rq "github.com/LumeraProtocol/rq-service/gen"
 	"github.com/LumeraProtocol/supernode/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/pkg/net"
 )

--- a/pkg/raptorq/encode.go
+++ b/pkg/raptorq/encode.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	rq "github.com/LumeraProtocol/rq-service"
+	rq "github.com/LumeraProtocol/rq-service/gen"
 	"github.com/LumeraProtocol/supernode/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/pkg/net"
 )

--- a/pkg/raptorq/encode_metadata.go
+++ b/pkg/raptorq/encode_metadata.go
@@ -3,7 +3,7 @@ package raptorq
 import (
 	"context"
 
-	rq "github.com/LumeraProtocol/rq-service"
+	rq "github.com/LumeraProtocol/rq-service/gen"
 	"github.com/LumeraProtocol/supernode/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/pkg/net"
 )


### PR DESCRIPTION
This pull request makes two important changes:


- Removes local replace directives in favor of using GitHub repositories
- Fixes module naming in both dd-service and rq-service by changing from the generic gen to their respective GitHub URL paths (/gen)


This also involved creating the release v0.4.2 for Lumera to make the latest Lumera changes available in supernode

