### PR TITLE
Update Stats to use atomic operations

### DIFF
--- a/pkg/net/credentials/alts/handshake/handshake_test.go
+++ b/pkg/net/credentials/alts/handshake/handshake_test.go
@@ -435,7 +435,7 @@ func TestHandshakerConcurrentHandshakes(t *testing.T) {
 			}
 
 			// Verify concurrent handshake limits
-			require.LessOrEqual(t, stat.MaxConcurrentCalls, maxConcurrentHandshakes,
+			require.LessOrEqual(t, stat.GetMaxConcurrentCalls(), maxConcurrentHandshakes,
 				"concurrent handshakes exceeded limit")
 		})
 	}


### PR DESCRIPTION

## Issue
The `TestHandshakerConcurrentHandshakes` test fails with a race condition when testing with maximum concurrent handshakes:
```
fatal error: concurrent map read and map write
goroutine 559 [running]:
internal/runtime/maps.fatal({...})
github.com/99designs/keyring.(*ArrayKeyring).Get(...)
github.com/cosmos/cosmos-sdk/crypto/keyring.keystore.KeyByAddress(...) 
github.com/LumeraProtocol/lumera/x/lumeraid/securekeyx.(*SecureKeyExchange).getLocalPubKey(...)
github.com/LumeraProtocol/lumera/x/lumeraid/securekeyx.(*SecureKeyExchange).CreateRequest(...)
```

## Changes
- Replaced mutex locks with atomic operations for thread-safe access
- Changed field types from `int` to `int32` to support atomic operations
- Added a `GetMaxConcurrentCalls()` accessor method for safe value retrieval 
- Updated the relevant tests to use the new accessor method

The update preserves the original API contract where `Update()` still returns a cleanup function that decrements the call count when invoked. These changes should reduce overhead in high-concurrency scenarios.