### PR TITLE
Fix P2P connection deadlines and credential separation

### DIFF
--- a/p2p/kademlia/conn_pool.go
+++ b/p2p/kademlia/conn_pool.go
@@ -203,21 +203,21 @@ func (conn *connWrapper) RemoteAddr() net.Addr {
 func (conn *connWrapper) SetDeadline(t time.Time) error {
 	conn.mtx.Lock()
 	defer conn.mtx.Unlock()
-	return conn.rawConn.SetDeadline(t)
+	return conn.secureConn.SetDeadline(t)
 }
 
 // SetReadDeadline implements net.Conn's SetReadDeadline interface
 func (conn *connWrapper) SetReadDeadline(t time.Time) error {
 	conn.mtx.Lock()
 	defer conn.mtx.Unlock()
-	return conn.rawConn.SetReadDeadline(t)
+	return conn.secureConn.SetReadDeadline(t)
 }
 
 // SetWriteDeadline implements net.Conn's SetWriteDeadline interface
 func (conn *connWrapper) SetWriteDeadline(t time.Time) error {
 	conn.mtx.Lock()
 	defer conn.mtx.Unlock()
-	return conn.rawConn.SetWriteDeadline(t)
+	return conn.secureConn.SetWriteDeadline(t)
 }
 
 // StartConnEviction starts a goroutine that periodically evicts idle connections.

--- a/p2p/kademlia/dht.go
+++ b/p2p/kademlia/dht.go
@@ -128,6 +128,19 @@ func NewDHT(ctx context.Context, store Store, metaStore MetaStore, options *Opti
 		return nil, fmt.Errorf("failed to create client credentials: %w", err)
 	}
 
+	// server creds for incoming
+	serverCreds, err := ltc.NewServerCreds(&ltc.ServerOptions{
+		CommonOptions: ltc.CommonOptions{
+			Keyring:       options.Keyring,
+			LocalIdentity: string(options.ID),
+			PeerType:      securekeyx.Supernode,
+			Validator:     lumera.NewSecureKeyExchangeValidator(options.LumeraClient),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create server credentials: %w", err)
+	}
+
 	// new a hashtable with options
 	ht, err := NewHashTable(options)
 	if err != nil {
@@ -139,7 +152,7 @@ func NewDHT(ctx context.Context, store Store, metaStore MetaStore, options *Opti
 	s.skipBadBootstrapAddrs()
 
 	// new network service for dht
-	network, err := NewNetwork(ctx, s, ht.self, clientCreds)
+	network, err := NewNetwork(ctx, s, ht.self, clientCreds, serverCreds)
 	if err != nil {
 		return nil, fmt.Errorf("new network: %v", err)
 	}

--- a/pkg/net/credentials/lumeratc.go
+++ b/pkg/net/credentials/lumeratc.go
@@ -100,7 +100,9 @@ func NewTransportCredentials(side Side, opts interface{}) (credentials.Transport
 	keyExMutex.Lock()
 	defer keyExMutex.Unlock()
 
-	keyExchanger, exists := keyExchangers[optsCommon.LocalIdentity]
+	// use side in cache key to separate client/server instances
+	cacheKey := fmt.Sprintf("%s-%d", optsCommon.LocalIdentity, side)
+	keyExchanger, exists := keyExchangers[cacheKey]
 	if !exists {
 		keyExchanger, err = securekeyx.NewSecureKeyExchange(
 			optsCommon.Keyring,
@@ -112,7 +114,7 @@ func NewTransportCredentials(side Side, opts interface{}) (credentials.Transport
 		if err != nil {
 			return nil, fmt.Errorf("failed to create secure key exchange: %w", err)
 		}
-		keyExchangers[optsCommon.LocalIdentity] = keyExchanger
+		keyExchangers[cacheKey] = keyExchanger
 	}
 
 	return &LumeraTC{


### PR DESCRIPTION

  - Fixed P2P nodes incorrectly marking active nodes as inactive due to stale connection deadlines
  - Resolved "message authentication failed" errors from shared ephemeral keys between client/server
  - Fixed "conn write: i/o timeout" errors from pooled connections retaining old deadlines

  ## Root Causes

  ### 1. Shared KeyExchanger Cache
  Client and server credentials were sharing the same KeyExchanger instance, causing ephemeral key collisions. When a node acted as both client and server, the
  shared key storage led to authentication failures with "ephemeral private key not found" errors.

  ### 2. Missing Per-Operation Deadlines
  Connections were created with a 10-minute deadline but never updated for individual operations. When `checkNodeActivity` sent pings expecting 10-second timeouts,
  the mismatch caused timeouts and nodes were incorrectly marked inactive.

  ### 3. Wrong Connection Layer for Deadlines
  The `connWrapper` was setting deadlines on the raw TCP connection instead of the ALTS encrypted connection layer, causing deadline operations to be ineffective.

  ## Changes

  ### Connection Management (`network.go`)
  - Added per-operation deadline refresh before each RPC call
  - Split single `tc` into `clientTC` and `serverTC` for proper credential separation
  - Ensures pooled connections get fresh deadlines matching operation timeout

  ### Credential Isolation (`lumeratc.go`)
  - Modified KeyExchanger cache key to include side (0=client, 1=server)
  - Prevents ephemeral key collision between client and server operations
  - Each side now maintains independent key storage

  ### Deadline Layer Fix (`conn_pool.go`)
  - Updated `SetDeadline`, `SetReadDeadline`, `SetWriteDeadline` to use `secureConn`
  - Ensures deadlines are set on the ALTS encryption layer, not raw TCP

  ### DHT Initialization (`dht.go`)
  - Created separate server credentials alongside existing client credentials
  - Both credentials passed to Network initialization
  - Proper separation of incoming vs outgoing connection handling

  ## Impact
  - No more false inactive node marking during health checks
  - Bidirectional P2P communication works without authentication errors
  - Connection pooling operates correctly with appropriate timeouts
