### PR TITLE
feat: add peer connectivity validation in SDK before task creation

### DIFF
--- a/sdk/task/manager.go
+++ b/sdk/task/manager.go
@@ -108,6 +108,12 @@ func (m *ManagerImpl) CreateCascadeTask(ctx context.Context, filePath string, ac
 		return "", err
 	}
 
+	// Check peer connectivity before creating task
+	if err := m.checkSupernodesPeerConnectivity(taskCtx, action.Height); err != nil {
+		cancel() // Clean up if peer check fails
+		return "", err
+	}
+
 	taskID := uuid.New().String()[:8]
 
 	m.logger.Debug(taskCtx, "Generated task ID", "taskID", taskID)
@@ -273,6 +279,12 @@ func (m *ManagerImpl) CreateDownloadTask(ctx context.Context, actionID string, o
 	if metadata.FileName == "" {
 		cancel() // Clean up if no filename
 		return "", fmt.Errorf("no filename found in cascade metadata")
+	}
+
+	// Check peer connectivity before creating task
+	if err := m.checkSupernodesPeerConnectivity(taskCtx, action.Height); err != nil {
+		cancel() // Clean up if peer check fails
+		return "", err
 	}
 
 	// Ensure the output path includes the correct filename


### PR DESCRIPTION
This pull request adds a new connectivity check to ensure that at least one supernode has P2P peers connected before creating cascade or download tasks. This helps prevent task creation when the network is not sufficiently connected, improving reliability and error handling.
