### PR TITLE
p2p design improvements and bug fixes

### DIFF
--- a/p2p/kademlia/banlist.go
+++ b/p2p/kademlia/banlist.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// banDuration - ban duration
-	banDuration = 3 * time.Hour
+	banDuration = 1 * time.Hour
 
 	// threshold - number of failures required to consider a node banned.
 	// failures before treating a node as banned.
@@ -170,14 +170,15 @@ func (s *BanList) ToNodeList() []*Node {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
-	ret := make([]*Node, 0)
-
+	ret := make([]*Node, 0, len(s.Nodes))
 	for i := 0; i < len(s.Nodes); i++ {
 		if s.Nodes[i].count > threshold {
-			ret = append(ret, &s.Nodes[i].Node)
+
+			n := s.Nodes[i].Node
+			n.SetHashedID()
+			ret = append(ret, &n)
 		}
 	}
-
 	return ret
 }
 

--- a/p2p/kademlia/bootstrap.go
+++ b/p2p/kademlia/bootstrap.go
@@ -3,51 +3,52 @@ package kademlia
 import (
 	"context"
 	"fmt"
+	"net"
+	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/LumeraProtocol/supernode/v2/p2p/kademlia/domain"
 	"github.com/LumeraProtocol/supernode/v2/pkg/errors"
-
 	"github.com/LumeraProtocol/supernode/v2/pkg/logtrace"
 	ltc "github.com/LumeraProtocol/supernode/v2/pkg/net/credentials"
 )
 
 const (
-	bootstrapRetryInterval  = 10
-	badAddrExpiryHours      = 12
-	defaultSuperNodeP2PPort = 4445
+	bootstrapRefreshInterval     = 10 * time.Minute
+	defaultSuperNodeP2PPort  int = 4445
 )
 
+// seed a couple of obviously bad addrs (unless in integration tests)
 func (s *DHT) skipBadBootstrapAddrs() {
-	//skipAddress1 := fmt.Sprintf("%s:%d", "127.0.0.1", s.options.Port)
-	//skipAddress2 := fmt.Sprintf("%s:%d", "localhost", s.options.Port)
-	//s.cache.Set(skipAddress1, []byte("true"))
-	//s.cache.Set(skipAddress2, []byte("true"))
+	isTest := os.Getenv("INTEGRATION_TEST") == "true"
+	if isTest {
+		return
+	}
+	s.cache.Set(fmt.Sprintf("%s:%d", "127.0.0.1", s.options.Port), []byte("true"))
+	s.cache.Set(fmt.Sprintf("%s:%d", "localhost", s.options.Port), []byte("true"))
 }
+
+// parseNode parses "host[:port]" into a Node with basic address hygiene.
+// Loopback/private allow-listed only in integration tests.
 func (s *DHT) parseNode(extP2P string, selfAddr string) (*Node, error) {
 	if extP2P == "" {
 		return nil, errors.New("empty address")
 	}
-
 	if extP2P == selfAddr {
 		return nil, errors.New("self address")
 	}
-
 	if _, err := s.cache.Get(extP2P); err == nil {
-		return nil, errors.New("configure: skip bad p2p boostrap addr")
+		return nil, errors.New("skip cached-bad bootstrap addr")
 	}
 
 	// Extract IP and port from the address
 	var ip string
 	var port uint16
-
 	if idx := strings.LastIndex(extP2P, ":"); idx != -1 {
 		ip = extP2P[:idx]
 		portStr := extP2P[idx+1:]
-
-		// If we have a port in the address, parse it
 		if portStr != "" {
 			portNum, err := strconv.ParseUint(portStr, 10, 16)
 			if err != nil {
@@ -56,33 +57,44 @@ func (s *DHT) parseNode(extP2P string, selfAddr string) (*Node, error) {
 			port = uint16(portNum)
 		}
 	} else {
-		// No port in the address
 		ip = extP2P
-		port = defaultSuperNodeP2PPort
+		port = uint16(defaultSuperNodeP2PPort)
 	}
-
 	if ip == "" {
 		return nil, errors.New("empty ip")
 	}
 
-	// Create the node with the correct IP and port
-	return &Node{
-		IP:   ip,
-		Port: port,
-	}, nil
+	// Hygiene: reject non-routables unless in integration tests
+	isTest := os.Getenv("INTEGRATION_TEST") == "true"
+	if parsed := net.ParseIP(ip); parsed != nil {
+		if parsed.IsUnspecified() || parsed.IsLinkLocalUnicast() || parsed.IsLinkLocalMulticast() {
+			return nil, errors.New("non-routable address")
+		}
+		if parsed.IsLoopback() && !isTest {
+			return nil, errors.New("loopback not allowed")
+		}
+		if parsed.IsPrivate() && !isTest {
+			return nil, errors.New("private address not allowed")
+		}
+	}
+
+	return &Node{IP: ip, Port: port}, nil
 }
 
-// setBootstrapNodesFromConfigVar parses config.bootstrapNodes and sets them
-// as the bootstrap nodes - As of now, this is only supposed to be used for testing
+// setBootstrapNodesFromConfigVar parses CSV of Lumera addresses and fills s.options.BootstrapNodes.
+// Intended for tests / controlled runs (no pings here).
 func (s *DHT) setBootstrapNodesFromConfigVar(ctx context.Context, bootstrapNodes string) error {
-	nodes := []*Node{}
+	nodes := make([]*Node, 0, 8)
 	bsNodes := strings.Split(bootstrapNodes, ",")
 	for _, bsNode := range bsNodes {
-		lumeraAddress, err := ltc.ParseLumeraAddress(bsNode)
+		addr := strings.TrimSpace(bsNode)
+		if addr == "" {
+			continue
+		}
+		lumeraAddress, err := ltc.ParseLumeraAddress(addr)
 		if err != nil {
 			return fmt.Errorf("setBootstrapNodesFromConfigVar: %w", err)
 		}
-
 		nodes = append(nodes, &Node{
 			ID:   []byte(lumeraAddress.Identity),
 			IP:   lumeraAddress.Host,
@@ -94,320 +106,215 @@ func (s *DHT) setBootstrapNodesFromConfigVar(ctx context.Context, bootstrapNodes
 		logtrace.FieldModule: "p2p",
 		"bootstrap_nodes":    nodes,
 	})
-
 	return nil
 }
 
-// loadBootstrapCandidatesFromChain queries the chain and builds a map of candidate nodes
-// keyed by their full "ip:port" address. Only active supernodes are considered and the
-// latest published IP and p2p port are used.
+// loadBootstrapCandidatesFromChain returns active supernodes (by latest state)
+// mapped by "ip:port". No pings here.
 func (s *DHT) loadBootstrapCandidatesFromChain(ctx context.Context, selfAddress string) (map[string]*Node, error) {
-	// Get all supernodes
-	supernodeResp, err := s.options.LumeraClient.SuperNode().ListSuperNodes(ctx)
+	resp, err := s.options.LumeraClient.SuperNode().ListSuperNodes(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get top supernodes: %w", err)
+		return nil, fmt.Errorf("failed to list supernodes: %w", err)
 	}
 
-	mapNodes := make(map[string]*Node, len(supernodeResp.Supernodes))
-
-	for _, supernode := range supernodeResp.Supernodes {
-		// Skip non-active supernodes - find latest state by height
-		if len(supernode.States) == 0 {
+	mapNodes := make(map[string]*Node, len(resp.Supernodes))
+	for _, sn := range resp.Supernodes {
+		if len(sn.States) == 0 {
 			continue
 		}
-
-		var latestState int32 = 0
+		var latestState int32
 		var maxStateHeight int64 = -1
-		for _, state := range supernode.States {
-			if state.Height > maxStateHeight {
-				maxStateHeight = state.Height
-				latestState = int32(state.State)
+		for _, st := range sn.States {
+			if st.Height > maxStateHeight {
+				maxStateHeight = st.Height
+				latestState = int32(st.State)
 			}
 		}
-
 		if latestState != 1 { // SuperNodeStateActive = 1
 			continue
 		}
 
-		// Find the latest IP address (with highest block height)
+		// latest IP by height
 		var latestIP string
 		var maxHeight int64 = -1
-		for _, ipHistory := range supernode.PrevIpAddresses {
-			if ipHistory.Height > maxHeight {
-				maxHeight = ipHistory.Height
-				latestIP = ipHistory.Address
+		for _, ipHist := range sn.PrevIpAddresses {
+			if ipHist.Height > maxHeight {
+				maxHeight = ipHist.Height
+				latestIP = ipHist.Address
 			}
 		}
-
 		if latestIP == "" {
-			logtrace.Warn(ctx, "No valid IP address found for supernode", logtrace.Fields{
+			logtrace.Warn(ctx, "No valid IP for supernode", logtrace.Fields{
 				logtrace.FieldModule: "p2p",
-				"supernode":          supernode.SupernodeAccount,
+				"supernode":          sn.SupernodeAccount,
 			})
 			continue
 		}
-
-		// Extract IP from the address (remove port if present)
 		ip := parseSupernodeAddress(latestIP)
 
-		// Use p2p_port from supernode record
 		p2pPort := defaultSuperNodeP2PPort
-		if supernode.P2PPort != "" {
-			if port, err := strconv.ParseUint(supernode.P2PPort, 10, 16); err == nil {
+		if sn.P2PPort != "" {
+			if port, err := strconv.ParseUint(sn.P2PPort, 10, 16); err == nil {
 				p2pPort = int(port)
 			}
 		}
 
-		// Create full address with p2p port for validation
-		fullAddress := fmt.Sprintf("%s:%d", ip, p2pPort)
-
-		// Parse the node from the full address
-		node, err := s.parseNode(fullAddress, selfAddress)
+		full := fmt.Sprintf("%s:%d", ip, p2pPort)
+		node, err := s.parseNode(full, selfAddress)
 		if err != nil {
-			logtrace.Warn(ctx, "Skip Bad Bootstrap Address", logtrace.Fields{
+			logtrace.Warn(ctx, "Skipping bootstrap candidate (bad addr)", logtrace.Fields{
 				logtrace.FieldModule: "p2p",
 				logtrace.FieldError:  err.Error(),
-				"address":            fullAddress,
-				"supernode":          supernode.SupernodeAccount,
+				"address":            full,
+				"supernode":          sn.SupernodeAccount,
 			})
 			continue
 		}
-
-		// Store the supernode account as the node ID
-		node.ID = []byte(supernode.SupernodeAccount)
-		mapNodes[fullAddress] = node
+		node.ID = []byte(sn.SupernodeAccount)
+		mapNodes[full] = node
 	}
-
 	return mapNodes, nil
 }
 
-// filterResponsiveByKademliaPing sends a Kademlia Ping RPC to each node and returns
-// only those that respond successfully.
-func (s *DHT) filterResponsiveByKademliaPing(ctx context.Context, nodes []*Node) []*Node {
-	maxInFlight := 32
-	if len(nodes) < maxInFlight {
-		maxInFlight = len(nodes)
+// upsertBootstrapNode inserts/updates replication_info for the discovered node (Active=false).
+// No pings or routing decisions here; the health loop will manage Active/LastSeen.
+func (s *DHT) upsertBootstrapNode(ctx context.Context, n *Node) error {
+	now := time.Now().UTC()
+	exists, err := s.store.RecordExists(string(n.ID))
+	if err != nil {
+		return fmt.Errorf("check replication record: %w", err)
 	}
-	if maxInFlight < 1 {
-		maxInFlight = 1
+	info := domain.NodeReplicationInfo{
+		ID:         n.ID,
+		IP:         n.IP,
+		Port:       n.Port,
+		Active:     false, // health loop flips to true when node responds
+		IsAdjusted: false,
+		UpdatedAt:  now,
 	}
-
-	type result struct {
-		node  *Node
-		alive bool
+	if exists {
+		return s.store.UpdateReplicationInfo(ctx, info)
 	}
+	return s.store.AddReplicationInfo(ctx, info)
+}
 
-	sem := make(chan struct{}, maxInFlight)
-	resCh := make(chan result, len(nodes))
-	var wg sync.WaitGroup
+// seedRoutingFromDB adds nodes (from replication_info) into the routing table (in-memory only).
+// Cheap; improves initial graph connectivity without pings.
+func (s *DHT) seedRoutingFromDB(ctx context.Context) {
+	repInfo, err := s.store.GetAllReplicationInfo(ctx)
+	if err != nil {
+		logtrace.Warn(ctx, "seed routing: get replication info failed", logtrace.Fields{
+			logtrace.FieldModule: "p2p",
+			logtrace.FieldError:  err.Error(),
+		})
+		return
+	}
+	for _, ri := range repInfo {
+		if len(ri.ID) == 0 || ri.IP == "" || ri.Port == 0 {
+			continue
+		}
+		n := &Node{ID: ri.ID, IP: ri.IP, Port: ri.Port}
+		s.addNode(ctx, n)
+	}
+}
 
-	for _, n := range nodes {
-		n := n
-		wg.Add(1)
-		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
-			defer func() { <-sem }()
-			req := s.newMessage(Ping, n, nil)
-			pctx, cancel := context.WithTimeout(ctx, defaultPingTime)
-			defer cancel()
-			_, err := s.network.Call(pctx, req, false)
-			if err != nil {
-				// penalize, but Bootstrap will still retry independently
-				s.ignorelist.IncrementCount(n)
-				logtrace.Debug(ctx, "kademlia ping failed during configure", logtrace.Fields{
+// SyncBootstrapOnce pulls candidates (config var or chain), upserts them into replication_info,
+// populates s.options.BootstrapNodes, and seeds the routing table. No pings here.
+func (s *DHT) SyncBootstrapOnce(ctx context.Context, bootstrapNodes string) error {
+	s.skipBadBootstrapAddrs()
+
+	// If config var provided, prefer that (tests)
+	if strings.TrimSpace(bootstrapNodes) != "" {
+		if err := s.setBootstrapNodesFromConfigVar(ctx, bootstrapNodes); err != nil {
+			return err
+		}
+		for _, n := range s.options.BootstrapNodes {
+			if err := s.upsertBootstrapNode(ctx, n); err != nil {
+				logtrace.Warn(ctx, "bootstrap upsert failed", logtrace.Fields{
 					logtrace.FieldModule: "p2p",
 					logtrace.FieldError:  err.Error(),
 					"node":               n.String(),
 				})
-				resCh <- result{node: n, alive: false}
-				return
 			}
-			resCh <- result{node: n, alive: true}
-		}()
-	}
-
-	wg.Wait()
-	close(resCh)
-
-	filtered := make([]*Node, 0, len(nodes))
-	for r := range resCh {
-		if r.alive {
-			filtered = append(filtered, r.node)
 		}
-	}
-	return filtered
-}
-
-// ConfigureBootstrapNodes connects with lumera client & gets p2p boostrap ip & port
-func (s *DHT) ConfigureBootstrapNodes(ctx context.Context, bootstrapNodes string) error {
-	if bootstrapNodes != "" {
-		return s.setBootstrapNodesFromConfigVar(ctx, bootstrapNodes)
+		s.seedRoutingFromDB(ctx)
+		return nil
 	}
 
+	// From chain
 	supernodeAddr, err := s.getSupernodeAddress(ctx)
 	if err != nil {
 		return fmt.Errorf("get supernode address: %s", err)
 	}
 	selfAddress := fmt.Sprintf("%s:%d", parseSupernodeAddress(supernodeAddr), s.options.Port)
 
-	// Load bootstrap candidates from chain
-	mapNodes, err := s.loadBootstrapCandidatesFromChain(ctx, selfAddress)
+	cands, err := s.loadBootstrapCandidatesFromChain(ctx, selfAddress)
 	if err != nil {
 		return err
 	}
 
-	// Build candidate list and filter only those that respond to Kademlia Ping
-	candidates := make([]*Node, 0, len(mapNodes))
-	for _, n := range mapNodes {
-		candidates = append(candidates, n)
-	}
-	pingResponsive := s.filterResponsiveByKademliaPing(ctx, candidates)
-	if len(pingResponsive) == 0 {
-		logtrace.Error(ctx, "no bootstrap nodes responded to Kademlia ping", logtrace.Fields{logtrace.FieldModule: "p2p"})
-		return nil
-	}
-
-	for _, node := range pingResponsive {
-		logtrace.Info(ctx, "adding p2p bootstrap node", logtrace.Fields{
-			logtrace.FieldModule: "p2p",
-			"bootstap_ip":        node.IP,
-			"bootstrap_port":     node.Port,
-			"node_id":            string(node.ID),
-		})
-	}
-
-	s.options.BootstrapNodes = append(s.options.BootstrapNodes, pingResponsive...)
-
-	return nil
-}
-
-// Bootstrap attempts to bootstrap the network using the BootstrapNodes provided
-// to the Options struct
-func (s *DHT) Bootstrap(ctx context.Context, bootstrapNodes string) error {
-	if len(s.options.BootstrapNodes) == 0 {
-		time.AfterFunc(bootstrapRetryInterval*time.Minute, func() {
-			s.retryBootstrap(ctx, bootstrapNodes)
-		})
-
-		return nil
-	}
-
-	var wg sync.WaitGroup
-	for _, node := range s.options.BootstrapNodes {
-		nodeId := string(node.ID)
-		// sync the bootstrap node only once
-		val, exists := s.bsConnected.Load(nodeId)
-		if exists {
-			isConnected, _ := val.(bool)
-			if isConnected {
-				continue
-			}
-		}
-
-		addr := fmt.Sprintf("%s:%v", node.IP, node.Port)
-		if _, err := s.cache.Get(addr); err == nil {
-			logtrace.Info(ctx, "skip bad p2p boostrap addr", logtrace.Fields{
+	// Upsert candidates to replication_info
+	seen := make(map[string]struct{}, len(cands))
+	s.options.BootstrapNodes = s.options.BootstrapNodes[:0]
+	for _, n := range cands {
+		if err := s.upsertBootstrapNode(ctx, n); err != nil {
+			logtrace.Warn(ctx, "bootstrap upsert failed", logtrace.Fields{
 				logtrace.FieldModule: "p2p",
-				"addr":               addr,
+				logtrace.FieldError:  err.Error(),
+				"node":               n.String(),
 			})
 			continue
 		}
-
-		node := node
-		s.bsConnected.Store(nodeId, false)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			// new a ping request message
-			request := s.newMessage(Ping, node, nil)
-			// new a context with timeout
-			ctx, cancel := context.WithTimeout(ctx, defaultPingTime)
-			defer cancel()
-
-			// invoke the request and handle the response
-			for i := 0; i < 5; i++ {
-				response, err := s.network.Call(ctx, request, false)
-				if err != nil {
-					// This happening in bootstrap - so potentially other nodes not yet started
-					// So if bootstrap failed, should try to connect to node again for next bootstrap retry
-					// Mark this address as temporarily bad to avoid retrying immediately
-					s.cache.SetWithExpiry(addr, []byte("true"), badAddrExpiryHours*time.Hour)
-
-					logtrace.Debug(ctx, "network call failed, sleeping 3 seconds", logtrace.Fields{
-						logtrace.FieldModule: "p2p",
-						logtrace.FieldError:  err.Error(),
-					})
-					time.Sleep(5 * time.Second)
-					continue
-				}
-				logtrace.Debug(ctx, "ping response", logtrace.Fields{
-					logtrace.FieldModule: "p2p",
-					"response":           response.String(),
-				})
-
-				// add the node to the route table
-				logtrace.Debug(ctx, "add-node params", logtrace.Fields{
-					logtrace.FieldModule: "p2p",
-					"sender-id":          string(response.Sender.ID),
-					"sender-ip":          string(response.Sender.IP),
-					"sender-port":        response.Sender.Port,
-				})
-
-				if len(response.Sender.ID) != len(s.ht.self.ID) {
-					logtrace.Error(ctx, "self ID && sender ID len don't match", logtrace.Fields{
-						logtrace.FieldModule: "p2p",
-						"sender-id":          string(response.Sender.ID),
-						"self-id":            string(s.ht.self.ID),
-					})
-
-					continue
-				}
-
-				s.bsConnected.Store(nodeId, true)
-				s.addNode(ctx, response.Sender)
-				break
-			}
-		}()
-	}
-
-	// wait until all are done
-	wg.Wait()
-
-	// if it has nodes in queries route tables
-	if s.ht.totalCount() > 0 {
-		// iterative find node from the nodes
-		if _, err := s.iterate(ctx, IterateFindNode, s.ht.self.ID, nil, 0); err != nil {
-			logtrace.Error(ctx, "iterative find node failed", logtrace.Fields{
-				logtrace.FieldModule: "p2p",
-				logtrace.FieldError:  err.Error(),
-			})
-			return err
+		if _, ok := seen[string(n.ID)]; ok {
+			continue
 		}
-	} else {
-		time.AfterFunc(bootstrapRetryInterval*time.Minute, func() {
-			s.retryBootstrap(ctx, bootstrapNodes)
-		})
+		s.options.BootstrapNodes = append(s.options.BootstrapNodes, n)
+		seen[string(n.ID)] = struct{}{}
 	}
 
+	// Seed routing
+	s.seedRoutingFromDB(ctx)
 	return nil
 }
 
-func (s *DHT) retryBootstrap(ctx context.Context, bootstrapNodes string) {
-	if err := s.ConfigureBootstrapNodes(ctx, bootstrapNodes); err != nil {
-		logtrace.Error(ctx, "retry failed to get bootstap ip", logtrace.Fields{
-			logtrace.FieldModule: "p2p",
-			logtrace.FieldError:  err.Error(),
-		})
-		return
+// StartBootstrapRefresher runs SyncBootstrapOnce every 10 minutes (idempotent upserts).
+// This keeps replication_info and routing table current as the validator set changes.
+func (s *DHT) StartBootstrapRefresher(ctx context.Context, bootstrapNodes string) {
+	go func() {
+		// Initial sync
+		if err := s.SyncBootstrapOnce(ctx, bootstrapNodes); err != nil {
+			logtrace.Warn(ctx, "initial bootstrap sync failed", logtrace.Fields{
+				logtrace.FieldModule: "p2p",
+				logtrace.FieldError:  err.Error(),
+			})
+		}
+		t := time.NewTicker(bootstrapRefreshInterval)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if err := s.SyncBootstrapOnce(ctx, bootstrapNodes); err != nil {
+					logtrace.Warn(ctx, "periodic bootstrap sync failed", logtrace.Fields{
+						logtrace.FieldModule: "p2p",
+						logtrace.FieldError:  err.Error(),
+					})
+				}
+			}
+		}
+	}()
+}
+
+// ConfigureBootstrapNodes wires to the new sync/refresher (no pings here).
+func (s *DHT) ConfigureBootstrapNodes(ctx context.Context, bootstrapNodes string) error {
+	// One-time sync; start refresher in the background
+	if err := s.SyncBootstrapOnce(ctx, bootstrapNodes); err != nil {
+		return err
 	}
 
-	// join the kademlia network if bootstrap nodes is set
-	if err := s.Bootstrap(ctx, bootstrapNodes); err != nil {
-		logtrace.Error(ctx, "retry failed - bootstrap the node.", logtrace.Fields{
-			logtrace.FieldModule: "p2p",
-			logtrace.FieldError:  err.Error(),
-		})
-	}
+	s.StartBootstrapRefresher(ctx, bootstrapNodes)
+
+	return nil
 }

--- a/p2p/kademlia/node_activity.go
+++ b/p2p/kademlia/node_activity.go
@@ -2,106 +2,140 @@ package kademlia
 
 import (
 	"context"
+	"math/rand/v2"
+	"sync"
 	"time"
 
 	"github.com/LumeraProtocol/supernode/v2/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/v2/pkg/utils"
 )
 
-// checkNodeActivity keeps track of active nodes - the idea here is to ping nodes periodically and mark them as inactive if they don't respond
+// checkNodeActivity keeps track of active nodes: ping periodically, mark inactive on sustained failure,
+// unban/re-add on success. Uses bounded concurrency and short per-ping timeouts.
 func (s *DHT) checkNodeActivity(ctx context.Context) {
+	ticker := time.NewTicker(checkNodeActivityInterval)
+	defer ticker.Stop()
+
+	const maxInflight = 32
+	sem := make(chan struct{}, maxInflight)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(checkNodeActivityInterval): // Adjust the interval as needed
+		case <-ticker.C:
 			if !utils.CheckInternetConnectivity() {
 				logtrace.Info(ctx, "no internet connectivity, not checking node activity", logtrace.Fields{})
-			} else {
-				repInfo, err := s.store.GetAllReplicationInfo(ctx)
-				if err != nil {
-					logtrace.Error(ctx, "get all replicationInfo failed", logtrace.Fields{
-						logtrace.FieldModule: "p2p",
-						logtrace.FieldError:  err.Error(),
-					})
-				}
-
-				for _, info := range repInfo {
-					// new a ping request message
-					node := &Node{
-						ID:   []byte(info.ID),
-						IP:   info.IP,
-						Port: info.Port,
-					}
-
-					request := s.newMessage(Ping, node, nil)
-
-					// invoke the request and handle the response
-					_, err := s.network.Call(ctx, request, false)
-					if err != nil {
-						logtrace.Debug(ctx, "failed to ping node", logtrace.Fields{
-							logtrace.FieldModule: "p2p",
-							logtrace.FieldError:  err.Error(),
-							"ip":                 info.IP,
-							"node_id":            string(info.ID),
-						})
-						if info.Active {
-							logtrace.Warn(ctx, "setting node to inactive", logtrace.Fields{
-								logtrace.FieldModule: "p2p",
-								logtrace.FieldError:  err.Error(),
-								"ip":                 info.IP,
-								"node_id":            string(info.ID),
-							})
-
-							// add node to ignore list
-							// we maintain this list to avoid pinging nodes that are not responding
-							s.ignorelist.IncrementCount(node)
-							// remove from route table
-							s.removeNode(ctx, node)
-
-							// mark node as inactive in database
-							if err := s.store.UpdateIsActive(ctx, string(info.ID), false, false); err != nil {
-								logtrace.Error(ctx, "failed to update replication info, node is inactive", logtrace.Fields{
-									logtrace.FieldModule: "p2p",
-									logtrace.FieldError:  err.Error(),
-									"ip":                 info.IP,
-									"node_id":            string(info.ID),
-								})
-							}
-						}
-
-					} else if err == nil {
-						// remove node from ignore list
-						s.ignorelist.Delete(node)
-
-						if !info.Active {
-							logtrace.Info(ctx, "node found to be active again", logtrace.Fields{
-								logtrace.FieldModule: "p2p",
-								"ip":                 info.IP,
-								"node_id":            string(info.ID),
-							})
-							// add node adds in the route table
-							s.addNode(ctx, node)
-							if err := s.store.UpdateIsActive(ctx, string(info.ID), true, false); err != nil {
-								logtrace.Error(ctx, "failed to update replication info, node is inactive", logtrace.Fields{
-									logtrace.FieldModule: "p2p",
-									logtrace.FieldError:  err.Error(),
-									"ip":                 info.IP,
-									"node_id":            string(info.ID),
-								})
-							}
-						}
-
-						if err := s.store.UpdateLastSeen(ctx, string(info.ID)); err != nil {
-							logtrace.Error(ctx, "failed to update last seen", logtrace.Fields{
-								logtrace.FieldError: err.Error(),
-								"ip":                info.IP,
-								"node_id":           string(info.ID),
-							})
-						}
-					}
-				}
+				continue
 			}
+
+			repInfo, err := s.store.GetAllReplicationInfo(ctx)
+			if err != nil {
+				logtrace.Error(ctx, "get all replicationInfo failed", logtrace.Fields{
+					logtrace.FieldModule: "p2p",
+					logtrace.FieldError:  err.Error(),
+				})
+				continue
+			}
+
+			rand.Shuffle(len(repInfo), func(i, j int) { repInfo[i], repInfo[j] = repInfo[j], repInfo[i] })
+
+			var wg sync.WaitGroup
+			for _, info := range repInfo {
+				info := info // capture
+				wg.Add(1)
+				sem <- struct{}{} // acquire
+				go func() {
+					defer wg.Done()
+					defer func() { <-sem }()
+
+					node := s.makeNode([]byte(info.ID), info.IP, info.Port)
+
+					// Short per-ping timeout (fail fast)
+					if err := s.pingNode(ctx, node, 3*time.Second); err != nil {
+						s.handlePingFailure(ctx, info.Active, node, err)
+						return
+					}
+					s.handlePingSuccess(ctx, info.Active, node)
+				}()
+			}
+			wg.Wait()
 		}
+	}
+}
+
+// ------------- Helper Funcs -----------------------//
+
+func (s *DHT) makeNode(id []byte, ip string, port uint16) *Node {
+	n := &Node{ID: id, IP: ip, Port: port}
+	n.SetHashedID()
+	return n
+}
+
+func (s *DHT) pingNode(ctx context.Context, n *Node, timeout time.Duration) error {
+	pctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req := s.newMessage(Ping, n, nil)
+	_, err := s.network.Call(pctx, req, false)
+	return err
+}
+
+func (s *DHT) handlePingFailure(ctx context.Context, wasActive bool, n *Node, err error) {
+	logtrace.Debug(ctx, "failed to ping node", logtrace.Fields{
+		logtrace.FieldModule: "p2p",
+		logtrace.FieldError:  err.Error(),
+		"ip":                 n.IP,
+		"node_id":            string(n.ID),
+	})
+
+	// increment soft-fail counter; only evict when past threshold
+	s.ignorelist.IncrementCount(n)
+	if wasActive && s.ignorelist.Banned(n) {
+		logtrace.Warn(ctx, "setting node to inactive", logtrace.Fields{
+			logtrace.FieldModule: "p2p",
+			logtrace.FieldError:  err.Error(),
+			"ip":                 n.IP,
+			"node_id":            string(n.ID),
+		})
+
+		s.removeNode(ctx, n) // uses HashedID internally
+		if uerr := s.store.UpdateIsActive(ctx, string(n.ID), false, false); uerr != nil {
+			logtrace.Error(ctx, "failed to update replication info, node is inactive", logtrace.Fields{
+				logtrace.FieldModule: "p2p",
+				logtrace.FieldError:  uerr.Error(),
+				"ip":                 n.IP,
+				"node_id":            string(n.ID),
+			})
+		}
+	}
+}
+
+func (s *DHT) handlePingSuccess(ctx context.Context, wasActive bool, n *Node) {
+	// clear from ignorelist and ensure presence in routing
+	s.ignorelist.Delete(n)
+
+	if !wasActive {
+		logtrace.Info(ctx, "node found to be active again", logtrace.Fields{
+			logtrace.FieldModule: "p2p",
+			"ip":                 n.IP,
+			"node_id":            string(n.ID),
+		})
+		s.addNode(ctx, n)
+		if uerr := s.store.UpdateIsActive(ctx, string(n.ID), true, false); uerr != nil {
+			logtrace.Error(ctx, "failed to update replication info, node is active", logtrace.Fields{
+				logtrace.FieldModule: "p2p",
+				logtrace.FieldError:  uerr.Error(),
+				"ip":                 n.IP,
+				"node_id":            string(n.ID),
+			})
+		}
+	}
+
+	if uerr := s.store.UpdateLastSeen(ctx, string(n.ID)); uerr != nil {
+		logtrace.Error(ctx, "failed to update last seen", logtrace.Fields{
+			logtrace.FieldError: uerr.Error(),
+			"ip":                n.IP,
+			"node_id":           string(n.ID),
+		})
 	}
 }

--- a/p2p/kademlia/redundant_data.go
+++ b/p2p/kademlia/redundant_data.go
@@ -80,7 +80,7 @@ func (s *DHT) cleanupRedundantDataWorker(ctx context.Context) {
 
 	for i := 0; i < len(replicationKeys); i++ {
 		decKey, _ := hex.DecodeString(replicationKeys[i].Key)
-		nodes := s.ht.closestContactsWithInlcudingNode(Alpha, decKey, ignores, self)
+		nodes := s.ht.closestContactsWithIncludingNode(Alpha, decKey, ignores, self)
 		closestContactsMap[replicationKeys[i].Key] = nodes.NodeIDs()
 	}
 

--- a/p2p/kademlia/replication.go
+++ b/p2p/kademlia/replication.go
@@ -173,7 +173,7 @@ func (s *DHT) Replicate(ctx context.Context) {
 
 	for i := 0; i < len(replicationKeys); i++ {
 		decKey, _ := hex.DecodeString(replicationKeys[i].Key)
-		closestContactsMap[replicationKeys[i].Key] = s.ht.closestContactsWithInlcudingNode(Alpha, decKey, ignores, self).NodeIDs()
+		closestContactsMap[replicationKeys[i].Key] = s.ht.closestContactsWithIncludingNode(Alpha, decKey, ignores, self).NodeIDs()
 	}
 
 	for _, info := range repInfo {
@@ -288,7 +288,7 @@ func (s *DHT) adjustNodeKeys(ctx context.Context, from time.Time, info domain.No
 
 		// get closest contacts to the key
 		key, _ := hex.DecodeString(replicationKeys[i].Key)
-		nodeList := s.ht.closestContactsWithInlcudingNode(Alpha+1, key, updatedIgnored, offNode) // +1 because we want to include the node we are adjusting
+		nodeList := s.ht.closestContactsWithIncludingNode(Alpha+1, key, updatedIgnored, offNode) // +1 because we want to include the node we are adjusting
 		// check if the node that is gone was supposed to hold the key
 		if !nodeList.Exists(offNode) {
 			// the node is not supposed to hold this key as its not in 6 closest contacts

--- a/p2p/kademlia/store/sqlite/sqlite_test.go
+++ b/p2p/kademlia/store/sqlite/sqlite_test.go
@@ -182,5 +182,7 @@ func TestStore(t *testing.T) {
 	os.Remove("data001-migration-meta.sqlite3")
 	os.Remove("data001.sqlite3-shm")
 	os.Remove("data001.sqlite3-wal")
+	os.Remove("data001-migration-meta.sqlite3-shm")
+	os.Remove("data001-migration-meta.sqlite3-wal")
 
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -93,13 +93,6 @@ func (s *p2p) run(ctx context.Context) error {
 		logtrace.Error(ctx, "failed to configure bootstrap nodes", logtrace.Fields{logtrace.FieldModule: "p2p", logtrace.FieldError: err})
 		logtrace.Error(ctx, "failed to get bootstap ip", logtrace.Fields{logtrace.FieldModule: "p2p", logtrace.FieldError: err})
 	}
-
-	// join the kademlia network if bootstrap nodes is set
-	if err := s.dht.Bootstrap(ctx, s.config.BootstrapNodes); err != nil {
-		// stop the node for kademlia network
-		s.dht.Stop(ctx)
-		return errors.Errorf("bootstrap the node: %w", err)
-	}
 	s.running = true
 
 	logtrace.Info(ctx, "p2p service is started", logtrace.Fields{})


### PR DESCRIPTION
# P2P: Make hot path fast & resilient — pooled TCP, dynamic deadlines, chunked BatchStore, smarter health/bans

## Summary
This PR hardens and speeds up the P2P stack without changing the wire protocol. The hot path no longer wastes RPCs or times out on heavy payloads, connections are responsibly reused, and node health is managed by a sober background loop (not by request-time heuristics).

**Headline changes**
- **Robust connection pooling**
  - Keyed by `bech32@host:port` for invariant identity.
  - `connWrapper` serializes whole-RPC I/O (prevents cross-talk on pooled sockets).
  - **One safe redial** on stale pooled sockets (EOF / reset / broken pipe).
  - Idle pruner (10m tick / 1h idle) + metrics: adds, hits, misses, evictions, open count.
  - TCP `NoDelay` (low latency) + server-side TCP keepalive (detect half-open).
- **Dynamic write deadlines**
  - Write deadline scaled to encoded size with cushion; outer call timeout widened for heavy ops.
  - Server read timeout keeps the connection open on timeouts (no churn).
- **Chunked `BatchStoreData`**
  - Per-node payload split into ~**180 MB** chunks (stays well under the **200 MB** hard cap).
  - Skips empty batches (no-op RPCs) and uses the long-timeout lane for large chunks.
- **Timeout tuning (realistic, payload-aware)**
  - `BatchStoreData`: **90s**, `BatchGetValues`: **90s**, `Find*/StoreData`: **5–15s**.
  - Client write deadlines derived from message size; read bounded by operation timeout.
- **Health & banlist behavior**
  - Background **checkNodeActivity** loop (2m, bounded concurrency) with 3s pings.
  - Only demote to inactive when failures exceed **threshold=3** (was 1).
  - Unban immediately on successful ping; routing table updated via health, not hot-path pings.
- **Bootstrap strategy (full network view)**
  - Periodic chain sync (10m) updates `replication_info` and seeds routing table.
  - No bootstrap-time pings; hot path relies on full view in-memory routing table (sized for ≤1000 validators).
- **Message safety**
  - Hard **200 MB** cap enforced in `encode/decode`; responders compress batch GETs.
  - Server continues on read timeout; client retries once on stale pooled socket.

---

## Key Changes (by area)

### Networking / I/O
- **Client (`Network.Call`)**
  - Whole-RPC lock on pooled connections; **one** redial on stale socket.
  - Dynamic `writeDeadline = base + size/throughputFloor + cushion`.
  - Deadlines cleared after every RPC (reusable pooled conns).
- **Server**
  - Per-message read deadline **90s**, but on timeout we **continue** (don’t close).
  - Write deadline per response (prevents hung writers).
  - TCP keepalive enabled on accepted sockets.

### Batch store
- **Per-node chunking (~180 MB)** to respect the 200 MB envelope after gob overhead.
- Skips empty batches (no more useless RPCs).
- Heavy chunks run with long-timeout profile; smaller ones complete faster.

### Health & bans
- Ban threshold **3**; health loop (2m) handles ban/unban and `Active` flip.
- Hot paths no longer make ban decisions; fewer false negatives and less churn.

### Bootstrap
- One-time + periodic (10m) chain sync → upsert `replication_info` and seed routing.
- No eager pings; routing table maintains full view for ≤1000 validators.

---

## Performance & Reliability Impact

- **Latency**: lower due to `TCP_NODELAY`, pooled conns, and no-reopen on server timeouts.
- **Throughput**: better because heavy writes get appropriate deadlines; chunking avoids cap hits.
- **Stability**: resilient to transient resets; background health avoids flapping & over-banning.
- **Resource use**: limited concurrent batch sends; idle pruner keeps pool bounded.

---

## Backward Compatibility
- No protocol changes; existing peers interoperate.
- Timeouts increased only for heavy ops; light RPCs unchanged or lowered.

---

## Configuration Knobs
- `BatchStoreData` timeout: **90s** (execTimeouts map).
- Chunk target: **~180 MB** raw payload (headroom under 200 MB cap).
- Pool pruner: **10m** tick, **1h** idle; pool capacity 256 (tunable).
- Health loop: **2m** cadence; per-ping timeout **3s**; ban threshold **3**.

---

## Risks & Mitigations
- **Large WAN variance**: dynamic write deadlines + longer outer timeouts for heavy ops.
- **Oversized messages**: 200 MB hard cap; chunking at ~180 MB prevents rejects.
- **Banlist sensitivity**: threshold bumped to 3; unban on successful ping.

**Rollback**: revert timeout map and chunker; server read timeout remains safe even when reduced.

---

## Testing Performed
- Unit: encode/decode size guard; stale-socket classification; chunker sizing.
- Integration:
  - Batch store with mixed 1–50 KB records up to caps; verified chunks <200 MB.
  - Induced server-side close/reset; ensured single redial recovers.
  - Ban/unban via health loop; confirmed no hot-path bans.

---

## Observability
- **Pool metrics**: adds/replacements/hits/misses/evictions/open_current/capacity.
- **Logs**: “Stale pooled connection on write/read; redialing” markers; batch chunk sizing & timing.
- **Health**: banlist size; `Active` flips; last_seen updates.

---

## Checklist
- [x] Connection pooling safe under concurrency
- [x] One redial on stale pooled socket
- [x] Dynamic write deadlines
- [x] Server read timeout keeps conn open
- [x] BatchStore chunking (~180 MB), no empty batches
- [x] 200 MB cap enforced
- [x] Health loop governs ban/unban (threshold=3)
- [x] Bootstrap refresher seeds routing; no hot-path find-node
- [x] Timeouts tuned (heavy ops 60–90s)

---
