### PR TITLE
Add wait after transaction broadcast when processing Tx after broadcast

### DIFF
--- a/pkg/lumera/modules/tx/interface.go
+++ b/pkg/lumera/modules/tx/interface.go
@@ -35,6 +35,9 @@ type Module interface {
 	// BroadcastTransaction broadcasts a signed transaction and returns the result
 	BroadcastTransaction(ctx context.Context, txBytes []byte) (*sdktx.BroadcastTxResponse, error)
 
+	// GetTransaction queries a transaction by its hash
+	GetTransaction(ctx context.Context, txHash string) (*sdktx.GetTxResponse, error)
+
 	// CalculateFee calculates the transaction fee based on gas usage and config
 	CalculateFee(gasAmount uint64, config *TxConfig) string
 

--- a/pkg/lumera/modules/tx/tx_mock.go
+++ b/pkg/lumera/modules/tx/tx_mock.go
@@ -58,6 +58,21 @@ func (mr *MockModuleMockRecorder) BroadcastTransaction(ctx, txBytes any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BroadcastTransaction", reflect.TypeOf((*MockModule)(nil).BroadcastTransaction), ctx, txBytes)
 }
 
+// GetTransaction mocks base method.
+func (m *MockModule) GetTransaction(ctx context.Context, txHash string) (*tx.GetTxResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransaction", ctx, txHash)
+	ret0, _ := ret[0].(*tx.GetTxResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransaction indicates an expected call of GetTransaction.
+func (mr *MockModuleMockRecorder) GetTransaction(ctx, txHash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransaction", reflect.TypeOf((*MockModule)(nil).GetTransaction), ctx, txHash)
+}
+
 // BuildAndSignTransaction mocks base method.
 func (m *MockModule) BuildAndSignTransaction(ctx context.Context, msgs []types.Msg, accountInfo *types0.BaseAccount, gasLimit uint64, fee string, config *TxConfig) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/pkg/testutil/lumera.go
+++ b/pkg/testutil/lumera.go
@@ -210,6 +210,12 @@ func (m *MockTxModule) ProcessTransaction(ctx context.Context, msgs []sdktypes.M
 	return &sdktx.BroadcastTxResponse{}, nil
 }
 
+// GetTransaction queries a transaction by its hash
+func (m *MockTxModule) GetTransaction(ctx context.Context, txHash string) (*sdktx.GetTxResponse, error) {
+	// Mock implementation returns empty transaction response
+	return &sdktx.GetTxResponse{}, nil
+}
+
 // MockNodeModule implements the node.Module interface for testing
 type MockNodeModule struct{}
 


### PR DESCRIPTION
This PR addresses an issue where transaction events are not immediately available after broadcasting a transaction. When a transaction is broadcast successfully but hasn't been included in a block yet, the initial response may have Code: 0 (success) but empty events array.
