### PR TITLE
hotfix: temporarily disable SDK/client complaint and storage challenge evidence submission

### DIFF
--- a/sdk/adapters/lumera/adapter.go
+++ b/sdk/adapters/lumera/adapter.go
@@ -2,11 +2,13 @@ package lumera
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
+	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
 	"github.com/LumeraProtocol/supernode/v2/sdk/log"
 
 	actiontypes "github.com/LumeraProtocol/lumera/x/action/v1/types"
@@ -389,13 +391,39 @@ func (a *Adapter) SubmitCascadeClientFailureEvidence(
 	targetSupernodeAccounts []string,
 	details map[string]string,
 ) error {
-	// TEMPORARY INCIDENT MITIGATION:
-	// Disabled per operational directive to prevent cascade client complaint evidence submissions.
-	a.logger.Warn(ctx, "Cascade client failure evidence submission is temporarily disabled",
-		"subject_address", strings.TrimSpace(subjectAddress),
-		"action_id", actionID,
-		"targets_count", len(targetSupernodeAccounts),
-	)
+	if a.client == nil {
+		return fmt.Errorf("lumera client is nil")
+	}
+	subjectAddress = strings.TrimSpace(subjectAddress)
+	if subjectAddress == "" {
+		return fmt.Errorf("subject address cannot be empty")
+	}
+	if details == nil {
+		details = map[string]string{}
+	}
+
+	meta := audittypes.CascadeClientFailureEvidenceMetadata{
+		ReporterComponent:       audittypes.CascadeClientFailureReporterComponent_CASCADE_CLIENT_FAILURE_REPORTER_COMPONENT_SDK_GO,
+		TargetSupernodeAccounts: append([]string(nil), targetSupernodeAccounts...),
+		Details:                 details,
+	}
+	bz, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal cascade client failure evidence metadata: %w", err)
+	}
+	_ = bz
+
+	// TEMPORARY INCIDENT MITIGATION: chain submission intentionally disabled.
+	// _, err = a.client.AuditMsg().SubmitEvidence(
+	// 	ctx,
+	// 	subjectAddress,
+	// 	audittypes.EvidenceType_EVIDENCE_TYPE_CASCADE_CLIENT_FAILURE,
+	// 	actionID,
+	// 	string(bz),
+	// )
+	if err != nil {
+		return fmt.Errorf("submit cascade client failure evidence: %w", err)
+	}
 	return nil
 }
 

--- a/sdk/adapters/lumera/adapter.go
+++ b/sdk/adapters/lumera/adapter.go
@@ -2,13 +2,11 @@ package lumera
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
-	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
 	"github.com/LumeraProtocol/supernode/v2/sdk/log"
 
 	actiontypes "github.com/LumeraProtocol/lumera/x/action/v1/types"
@@ -391,37 +389,13 @@ func (a *Adapter) SubmitCascadeClientFailureEvidence(
 	targetSupernodeAccounts []string,
 	details map[string]string,
 ) error {
-	if a.client == nil {
-		return fmt.Errorf("lumera client is nil")
-	}
-	subjectAddress = strings.TrimSpace(subjectAddress)
-	if subjectAddress == "" {
-		return fmt.Errorf("subject address cannot be empty")
-	}
-	if details == nil {
-		details = map[string]string{}
-	}
-
-	meta := audittypes.CascadeClientFailureEvidenceMetadata{
-		ReporterComponent:       audittypes.CascadeClientFailureReporterComponent_CASCADE_CLIENT_FAILURE_REPORTER_COMPONENT_SDK_GO,
-		TargetSupernodeAccounts: append([]string(nil), targetSupernodeAccounts...),
-		Details:                 details,
-	}
-	bz, err := json.Marshal(meta)
-	if err != nil {
-		return fmt.Errorf("marshal cascade client failure evidence metadata: %w", err)
-	}
-
-	_, err = a.client.AuditMsg().SubmitEvidence(
-		ctx,
-		subjectAddress,
-		audittypes.EvidenceType_EVIDENCE_TYPE_CASCADE_CLIENT_FAILURE,
-		actionID,
-		string(bz),
+	// TEMPORARY INCIDENT MITIGATION:
+	// Disabled per operational directive to prevent cascade client complaint evidence submissions.
+	a.logger.Warn(ctx, "Cascade client failure evidence submission is temporarily disabled",
+		"subject_address", strings.TrimSpace(subjectAddress),
+		"action_id", actionID,
+		"targets_count", len(targetSupernodeAccounts),
 	)
-	if err != nil {
-		return fmt.Errorf("submit cascade client failure evidence: %w", err)
-	}
 	return nil
 }
 

--- a/sdk/adapters/lumera/adapter.go
+++ b/sdk/adapters/lumera/adapter.go
@@ -421,9 +421,9 @@ func (a *Adapter) SubmitCascadeClientFailureEvidence(
 	// 	actionID,
 	// 	string(bz),
 	// )
-	if err != nil {
-		return fmt.Errorf("submit cascade client failure evidence: %w", err)
-	}
+	// if err != nil {
+	// 	return fmt.Errorf("submit cascade client failure evidence: %w", err)
+	// }
 	return nil
 }
 

--- a/supernode/storage_challenge/service.go
+++ b/supernode/storage_challenge/service.go
@@ -583,44 +583,17 @@ func (s *Service) callVerifySliceProof(ctx context.Context, remoteIdentity strin
 }
 
 func (s *Service) maybeSubmitEvidence(ctx context.Context, params audittypes.Params, epochID uint64, challengeID, fileKey, recipient, failureType, transcriptHashHex string) error {
-	if !s.cfg.SubmitEvidence || !params.ScEnabled {
-		logtrace.Debug(ctx, "storage challenge: evidence submission skipped", logtrace.Fields{
-			"epoch_id":               epochID,
-			"challenge_id":           challengeID,
-			"recipient_id":           recipient,
-			"failure_type":           failureType,
-			"submit_evidence_config": s.cfg.SubmitEvidence,
-			"sc_enabled_param":       params.ScEnabled,
-		})
-		return nil
-	}
+	_ = params
+	_ = transcriptHashHex
 
-	meta := audittypes.StorageChallengeFailureEvidenceMetadata{
-		EpochId:                    epochID,
-		ChallengerSupernodeAccount: s.identity,
-		ChallengedSupernodeAccount: recipient,
-		ChallengeId:                challengeID,
-		FileKey:                    fileKey,
-		FailureType:                failureType,
-		TranscriptHash:             transcriptHashHex,
-	}
-	bz, err := json.Marshal(meta)
-	if err != nil {
-		return err
-	}
-
-	submitCtx, cancel := context.WithTimeout(ctx, scEvidenceSubmitTimeout)
-	defer cancel()
-
-	_, err = s.lumera.AuditMsg().SubmitEvidence(submitCtx, recipient, audittypes.EvidenceType_EVIDENCE_TYPE_STORAGE_CHALLENGE_FAILURE, "", string(bz))
-	if err != nil {
-		return err
-	}
-	logtrace.Warn(ctx, "storage challenge failure evidence submitted", logtrace.Fields{
+	// TEMPORARY INCIDENT MITIGATION:
+	// Disabled per operational directive to pause storage challenge evidence submissions.
+	logtrace.Warn(ctx, "storage challenge: evidence submission temporarily disabled", logtrace.Fields{
 		"epoch_id":     epochID,
 		"challenge_id": challengeID,
 		"recipient_id": recipient,
 		"failure_type": failureType,
+		"file_key":     fileKey,
 	})
 	return nil
 }

--- a/supernode/storage_challenge/service.go
+++ b/supernode/storage_challenge/service.go
@@ -616,9 +616,9 @@ func (s *Service) maybeSubmitEvidence(ctx context.Context, params audittypes.Par
 
 	// TEMPORARY INCIDENT MITIGATION: chain submission intentionally disabled.
 	// _, err = s.lumera.AuditMsg().SubmitEvidence(submitCtx, recipient, audittypes.EvidenceType_EVIDENCE_TYPE_STORAGE_CHALLENGE_FAILURE, "", string(bz))
-	if err != nil {
-		return err
-	}
+	// if err != nil {
+	// 	return err
+	// }
 	logtrace.Warn(ctx, "storage challenge failure evidence submission temporarily disabled", logtrace.Fields{
 		"epoch_id":     epochID,
 		"challenge_id": challengeID,

--- a/supernode/storage_challenge/service.go
+++ b/supernode/storage_challenge/service.go
@@ -583,17 +583,47 @@ func (s *Service) callVerifySliceProof(ctx context.Context, remoteIdentity strin
 }
 
 func (s *Service) maybeSubmitEvidence(ctx context.Context, params audittypes.Params, epochID uint64, challengeID, fileKey, recipient, failureType, transcriptHashHex string) error {
-	_ = params
-	_ = transcriptHashHex
+	if !s.cfg.SubmitEvidence || !params.ScEnabled {
+		logtrace.Debug(ctx, "storage challenge: evidence submission skipped", logtrace.Fields{
+			"epoch_id":               epochID,
+			"challenge_id":           challengeID,
+			"recipient_id":           recipient,
+			"failure_type":           failureType,
+			"submit_evidence_config": s.cfg.SubmitEvidence,
+			"sc_enabled_param":       params.ScEnabled,
+		})
+		return nil
+	}
 
-	// TEMPORARY INCIDENT MITIGATION:
-	// Disabled per operational directive to pause storage challenge evidence submissions.
-	logtrace.Warn(ctx, "storage challenge: evidence submission temporarily disabled", logtrace.Fields{
+	meta := audittypes.StorageChallengeFailureEvidenceMetadata{
+		EpochId:                    epochID,
+		ChallengerSupernodeAccount: s.identity,
+		ChallengedSupernodeAccount: recipient,
+		ChallengeId:                challengeID,
+		FileKey:                    fileKey,
+		FailureType:                failureType,
+		TranscriptHash:             transcriptHashHex,
+	}
+	bz, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+
+	submitCtx, cancel := context.WithTimeout(ctx, scEvidenceSubmitTimeout)
+	defer cancel()
+	_ = submitCtx
+	_ = bz
+
+	// TEMPORARY INCIDENT MITIGATION: chain submission intentionally disabled.
+	// _, err = s.lumera.AuditMsg().SubmitEvidence(submitCtx, recipient, audittypes.EvidenceType_EVIDENCE_TYPE_STORAGE_CHALLENGE_FAILURE, "", string(bz))
+	if err != nil {
+		return err
+	}
+	logtrace.Warn(ctx, "storage challenge failure evidence submission temporarily disabled", logtrace.Fields{
 		"epoch_id":     epochID,
 		"challenge_id": challengeID,
 		"recipient_id": recipient,
 		"failure_type": failureType,
-		"file_key":     fileKey,
 	})
 	return nil
 }


### PR DESCRIPTION
## Summary
Temporary incident-response mitigation to stop audit evidence submissions from supernode paths that can contribute risk during stabilization.

## Changes
- Disable SDK cascade client complaint evidence submission:
  - `sdk/adapters/lumera/adapter.go`
  - `SubmitCascadeClientFailureEvidence(...)` now logs and returns without broadcasting tx.
- Disable storage challenge failure evidence submission:
  - `supernode/storage_challenge/service.go`
  - `maybeSubmitEvidence(...)` now logs and returns without broadcasting tx.

## Validation
- `go test ./sdk/adapters/lumera ./sdk/task ./supernode/storage_challenge`

## Notes
- This is intentional temporary mitigation per ops directive.
- Re-enable should be done in a follow-up PR once chain-side determinism hardening and validation are fully complete.
