### PR TITLE
feat(tx): lower default gas_adjustment to 1.3, make tuning configurable, retry on OOG

### DIFF
--- a/pkg/lumera/client.go
+++ b/pkg/lumera/client.go
@@ -92,40 +92,34 @@ func newClient(ctx context.Context, cfg *Config) (Client, error) {
 		}
 	}
 
-	actionMsgModule, err := action_msg.NewModule(
+	actionMsgModule, err := action_msg.NewModuleWithTxHelperConfig(
 		conn.GetConn(),
-		authModule,  // For account info
-		txModule,    // For transaction operations
-		cfg.keyring, // For signing
-		cfg.KeyName, // Key to use
-		cfg.ChainID, // Chain configuration
+		authModule, // For account info
+		txModule,   // For transaction operations
+		cfg.toTxHelperConfig(),
 	)
 	if err != nil {
 		conn.Close()
 		return nil, err
 	}
 
-	supernodeMsgModule, err := supernode_msg.NewModule(
+	supernodeMsgModule, err := supernode_msg.NewModuleWithTxHelperConfig(
 		conn.GetConn(),
 		authModule,
 		txModule,
 		supernodeModule,
-		cfg.keyring,
-		cfg.KeyName,
-		cfg.ChainID,
+		cfg.toTxHelperConfig(),
 	)
 	if err != nil {
 		conn.Close()
 		return nil, err
 	}
 
-	auditMsgModule, err := audit_msg.NewModule(
+	auditMsgModule, err := audit_msg.NewModuleWithTxHelperConfig(
 		conn.GetConn(),
 		authModule,
 		txModule,
-		cfg.keyring,
-		cfg.KeyName,
-		cfg.ChainID,
+		cfg.toTxHelperConfig(),
 	)
 	if err != nil {
 		conn.Close()

--- a/pkg/lumera/config.go
+++ b/pkg/lumera/config.go
@@ -3,8 +3,50 @@ package lumera
 import (
 	"fmt"
 
+	"github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/tx"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 )
+
+// TxOptions holds the tunable gas/fee parameters used by the Lumera client
+// when building, signing, and broadcasting transactions. Zero-valued fields
+// are replaced by the package defaults declared in pkg/lumera/modules/tx.
+//
+// Intended use: operators who want to lower fee spend (or raise it for
+// safety) without a code change can populate these via the supernode YAML
+// config under `lumera.tx_*` keys.
+type TxOptions struct {
+	// GasAdjustment multiplies simulated gas to derive gas_wanted.
+	// Lower → smaller fee but higher OOG risk. Default: 1.3.
+	GasAdjustment float64
+	// GasAdjustmentMultiplier is applied to GasAdjustment on each OOG
+	// retry. Must be >1. Default: 1.3.
+	GasAdjustmentMultiplier float64
+	// GasAdjustmentMaxAttempts is the total number of attempts
+	// (initial + retries) before giving up on an OOG failure. Default: 3.
+	GasAdjustmentMaxAttempts int
+	// GasPadding is added to gas_wanted after gas_adjustment. Default: 50000.
+	GasPadding uint64
+	// GasPrice is the unit fee (e.g. "0.025" or "0.025ulume"). Default: "0.025".
+	GasPrice string
+	// FeeDenom is the coin denom used for fees. Default: "ulume".
+	FeeDenom string
+}
+
+// toTxHelperConfig materializes a tx.TxHelperConfig from the Config. Zero-valued
+// options remain zero so tx.NewTxHelper applies defaults deterministically.
+func (c *Config) toTxHelperConfig() *tx.TxHelperConfig {
+	return &tx.TxHelperConfig{
+		ChainID:                  c.ChainID,
+		Keyring:                  c.keyring,
+		KeyName:                  c.KeyName,
+		GasAdjustment:            c.TxOptions.GasAdjustment,
+		GasAdjustmentMultiplier:  c.TxOptions.GasAdjustmentMultiplier,
+		GasAdjustmentMaxAttempts: c.TxOptions.GasAdjustmentMaxAttempts,
+		GasPadding:               c.TxOptions.GasPadding,
+		GasPrice:                 c.TxOptions.GasPrice,
+		FeeDenom:                 c.TxOptions.FeeDenom,
+	}
+}
 
 // Config holds all the configuration needed for the client
 type Config struct {
@@ -19,27 +61,38 @@ type Config struct {
 
 	// KeyName is the name of the key to use for signing
 	KeyName string
+
+	// TxOptions tunes fee/gas behavior for outbound transactions. All fields
+	// are optional; zero-valued fields fall back to pkg/lumera/modules/tx
+	// defaults.
+	TxOptions TxOptions
 }
 
-func NewConfig(grpcAddr, chainID string, keyName string, keyring keyring.Keyring) (*Config, error) {
-
+// NewConfig creates a client config using default TxOptions. Additional TxOptions
+// can be supplied; the last one wins. Keeping TxOptions variadic preserves
+// source-level compatibility with existing callers.
+func NewConfig(grpcAddr, chainID string, keyName string, kr keyring.Keyring, opts ...TxOptions) (*Config, error) {
 	if grpcAddr == "" {
 		return nil, fmt.Errorf("grpcAddr cannot be empty")
 	}
 	if chainID == "" {
 		return nil, fmt.Errorf("chainID cannot be empty")
 	}
-	if keyring == nil {
+	if kr == nil {
 		return nil, fmt.Errorf("keyring cannot be nil")
 	}
 	if keyName == "" {
 		return nil, fmt.Errorf("keyName cannot be empty")
 	}
 
-	return &Config{
+	cfg := &Config{
 		GRPCAddr: grpcAddr,
 		ChainID:  chainID,
-		keyring:  keyring,
+		keyring:  kr,
 		KeyName:  keyName,
-	}, nil
+	}
+	for _, o := range opts {
+		cfg.TxOptions = o
+	}
+	return cfg, nil
 }

--- a/pkg/lumera/config_test.go
+++ b/pkg/lumera/config_test.go
@@ -1,0 +1,84 @@
+package lumera
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+)
+
+func TestNewConfig_DefaultTxOptionsZeroed(t *testing.T) {
+	t.Parallel()
+	kr := keyring.NewInMemory(nil)
+	cfg, err := NewConfig("localhost:9090", "testing", "key", kr)
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	if cfg.TxOptions.GasAdjustment != 0 {
+		t.Errorf("GasAdjustment = %v, want 0 (zero → default at TxHelper layer)", cfg.TxOptions.GasAdjustment)
+	}
+}
+
+func TestNewConfig_TxOptionsPropagated(t *testing.T) {
+	t.Parallel()
+	kr := keyring.NewInMemory(nil)
+	cfg, err := NewConfig("localhost:9090", "testing", "key", kr, TxOptions{
+		GasAdjustment:            1.21,
+		GasAdjustmentMultiplier:  1.5,
+		GasAdjustmentMaxAttempts: 4,
+		GasPadding:               99,
+		GasPrice:                 "0.030",
+		FeeDenom:                 "ulume",
+	})
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	thc := cfg.toTxHelperConfig()
+	if thc.GasAdjustment != 1.21 {
+		t.Errorf("GasAdjustment = %v, want 1.21", thc.GasAdjustment)
+	}
+	if thc.GasAdjustmentMultiplier != 1.5 {
+		t.Errorf("GasAdjustmentMultiplier = %v, want 1.5", thc.GasAdjustmentMultiplier)
+	}
+	if thc.GasAdjustmentMaxAttempts != 4 {
+		t.Errorf("GasAdjustmentMaxAttempts = %v, want 4", thc.GasAdjustmentMaxAttempts)
+	}
+	if thc.GasPadding != 99 {
+		t.Errorf("GasPadding = %v, want 99", thc.GasPadding)
+	}
+	if thc.GasPrice != "0.030" {
+		t.Errorf("GasPrice = %q, want 0.030", thc.GasPrice)
+	}
+	if thc.FeeDenom != "ulume" {
+		t.Errorf("FeeDenom = %q, want ulume", thc.FeeDenom)
+	}
+	if thc.ChainID != "testing" || thc.KeyName != "key" {
+		t.Errorf("ChainID/KeyName not propagated: %+v", thc)
+	}
+}
+
+func TestNewConfig_RejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+	kr := keyring.NewInMemory(nil)
+	cases := []struct {
+		name  string
+		grpc  string
+		chain string
+		key   string
+		kr    keyring.Keyring
+	}{
+		{"empty grpc", "", "x", "k", kr},
+		{"empty chain", "host", "", "k", kr},
+		{"nil keyring", "host", "x", "k", nil},
+		{"empty key", "host", "x", "", kr},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewConfig(tc.grpc, tc.chain, tc.key, tc.kr); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}

--- a/pkg/lumera/modules/action_msg/impl.go
+++ b/pkg/lumera/modules/action_msg/impl.go
@@ -8,7 +8,6 @@ import (
 	actiontypes "github.com/LumeraProtocol/lumera/x/action/v1/types"
 	"github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/auth"
 	txmod "github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/tx"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"google.golang.org/grpc"
@@ -20,7 +19,10 @@ type module struct {
 	mu       sync.Mutex
 }
 
-func newModule(conn *grpc.ClientConn, authmodule auth.Module, txmodule txmod.Module, kr keyring.Keyring, keyName string, chainID string) (Module, error) {
+// newModuleWithHelper creates the action_msg module using the supplied
+// TxHelperConfig. The config is normalized inside tx.NewTxHelper (zero-valued
+// fields fall back to defaults).
+func newModuleWithHelper(conn *grpc.ClientConn, authmodule auth.Module, txmodule txmod.Module, cfg *txmod.TxHelperConfig) (Module, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("connection cannot be nil")
 	}
@@ -30,19 +32,22 @@ func newModule(conn *grpc.ClientConn, authmodule auth.Module, txmodule txmod.Mod
 	if txmodule == nil {
 		return nil, fmt.Errorf("tx module cannot be nil")
 	}
-	if kr == nil {
+	if cfg == nil {
+		return nil, fmt.Errorf("tx helper config cannot be nil")
+	}
+	if cfg.Keyring == nil {
 		return nil, fmt.Errorf("keyring cannot be nil")
 	}
-	if keyName == "" {
+	if cfg.KeyName == "" {
 		return nil, fmt.Errorf("key name cannot be empty")
 	}
-	if chainID == "" {
+	if cfg.ChainID == "" {
 		return nil, fmt.Errorf("chain ID cannot be empty")
 	}
 
 	return &module{
 		client:   actiontypes.NewMsgClient(conn),
-		txHelper: txmod.NewTxHelperWithDefaults(authmodule, txmodule, chainID, keyName, kr),
+		txHelper: txmod.NewTxHelper(authmodule, txmodule, cfg),
 	}, nil
 }
 

--- a/pkg/lumera/modules/action_msg/interface.go
+++ b/pkg/lumera/modules/action_msg/interface.go
@@ -19,6 +19,19 @@ type Module interface {
 	SimulateFinalizeCascadeAction(ctx context.Context, actionId string, rqIdsIds []string) (*sdktx.SimulateResponse, error)
 }
 
+// NewModule creates an action_msg module using default TxHelper settings.
+// Preserved for backward compatibility. For customized gas policy use NewModuleWithTxHelperConfig.
 func NewModule(conn *grpc.ClientConn, authmod auth.Module, txmodule tx.Module, kr keyring.Keyring, keyName string, chainID string) (Module, error) {
-	return newModule(conn, authmod, txmodule, kr, keyName, chainID)
+	return newModuleWithHelper(conn, authmod, txmodule, &tx.TxHelperConfig{
+		ChainID: chainID,
+		Keyring: kr,
+		KeyName: keyName,
+	})
+}
+
+// NewModuleWithTxHelperConfig creates an action_msg module with an explicit TxHelper configuration.
+// Zero-valued fields in cfg fall back to package defaults (see tx.DefaultGas* constants).
+// cfg.ChainID / cfg.Keyring / cfg.KeyName are required (validated inside newModuleWithHelper).
+func NewModuleWithTxHelperConfig(conn *grpc.ClientConn, authmod auth.Module, txmodule tx.Module, cfg *tx.TxHelperConfig) (Module, error) {
+	return newModuleWithHelper(conn, authmod, txmodule, cfg)
 }

--- a/pkg/lumera/modules/audit_msg/audit_msg_mock.go
+++ b/pkg/lumera/modules/audit_msg/audit_msg_mock.go
@@ -42,21 +42,6 @@ func (m *MockModule) EXPECT() *MockModuleMockRecorder {
 	return m.recorder
 }
 
-// SubmitEvidence mocks base method.
-func (m *MockModule) SubmitEvidence(ctx context.Context, subjectAddress string, evidenceType types.EvidenceType, actionID, metadataJSON string) (*tx.BroadcastTxResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitEvidence", ctx, subjectAddress, evidenceType, actionID, metadataJSON)
-	ret0, _ := ret[0].(*tx.BroadcastTxResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SubmitEvidence indicates an expected call of SubmitEvidence.
-func (mr *MockModuleMockRecorder) SubmitEvidence(ctx, subjectAddress, evidenceType, actionID, metadataJSON any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitEvidence", reflect.TypeOf((*MockModule)(nil).SubmitEvidence), ctx, subjectAddress, evidenceType, actionID, metadataJSON)
-}
-
 // SubmitEpochReport mocks base method.
 func (m *MockModule) SubmitEpochReport(ctx context.Context, epochID uint64, hostReport types.HostReport, storageChallengeObservations []*types.StorageChallengeObservation) (*tx.BroadcastTxResponse, error) {
 	m.ctrl.T.Helper()
@@ -70,4 +55,19 @@ func (m *MockModule) SubmitEpochReport(ctx context.Context, epochID uint64, host
 func (mr *MockModuleMockRecorder) SubmitEpochReport(ctx, epochID, hostReport, storageChallengeObservations any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitEpochReport", reflect.TypeOf((*MockModule)(nil).SubmitEpochReport), ctx, epochID, hostReport, storageChallengeObservations)
+}
+
+// SubmitEvidence mocks base method.
+func (m *MockModule) SubmitEvidence(ctx context.Context, subjectAddress string, evidenceType types.EvidenceType, actionID, metadataJSON string) (*tx.BroadcastTxResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubmitEvidence", ctx, subjectAddress, evidenceType, actionID, metadataJSON)
+	ret0, _ := ret[0].(*tx.BroadcastTxResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubmitEvidence indicates an expected call of SubmitEvidence.
+func (mr *MockModuleMockRecorder) SubmitEvidence(ctx, subjectAddress, evidenceType, actionID, metadataJSON any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitEvidence", reflect.TypeOf((*MockModule)(nil).SubmitEvidence), ctx, subjectAddress, evidenceType, actionID, metadataJSON)
 }

--- a/pkg/lumera/modules/audit_msg/impl.go
+++ b/pkg/lumera/modules/audit_msg/impl.go
@@ -9,7 +9,6 @@ import (
 	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
 	"github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/auth"
 	txmod "github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/tx"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"google.golang.org/grpc"
@@ -21,13 +20,13 @@ type module struct {
 	mu       sync.Mutex
 }
 
-func newModule(
+// newModuleWithHelper creates the audit_msg module using the supplied
+// TxHelperConfig (normalized by tx.NewTxHelper).
+func newModuleWithHelper(
 	conn *grpc.ClientConn,
 	authmodule auth.Module,
 	txmodule txmod.Module,
-	kr keyring.Keyring,
-	keyName string,
-	chainID string,
+	cfg *txmod.TxHelperConfig,
 ) (Module, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("connection cannot be nil")
@@ -38,19 +37,22 @@ func newModule(
 	if txmodule == nil {
 		return nil, fmt.Errorf("tx module cannot be nil")
 	}
-	if kr == nil {
+	if cfg == nil {
+		return nil, fmt.Errorf("tx helper config cannot be nil")
+	}
+	if cfg.Keyring == nil {
 		return nil, fmt.Errorf("keyring cannot be nil")
 	}
-	if strings.TrimSpace(keyName) == "" {
+	if strings.TrimSpace(cfg.KeyName) == "" {
 		return nil, fmt.Errorf("key name cannot be empty")
 	}
-	if strings.TrimSpace(chainID) == "" {
+	if strings.TrimSpace(cfg.ChainID) == "" {
 		return nil, fmt.Errorf("chain ID cannot be empty")
 	}
 
 	return &module{
 		client:   audittypes.NewMsgClient(conn),
-		txHelper: txmod.NewTxHelperWithDefaults(authmodule, txmodule, chainID, keyName, kr),
+		txHelper: txmod.NewTxHelper(authmodule, txmodule, cfg),
 	}, nil
 }
 

--- a/pkg/lumera/modules/audit_msg/interface.go
+++ b/pkg/lumera/modules/audit_msg/interface.go
@@ -18,7 +18,8 @@ type Module interface {
 	SubmitEpochReport(ctx context.Context, epochID uint64, hostReport audittypes.HostReport, storageChallengeObservations []*audittypes.StorageChallengeObservation) (*sdktx.BroadcastTxResponse, error)
 }
 
-// NewModule creates a new audit_msg module instance.
+// NewModule creates a new audit_msg module instance using default TxHelper
+// settings (see tx.DefaultGas* constants).
 func NewModule(
 	conn *grpc.ClientConn,
 	authmodule auth.Module,
@@ -27,5 +28,21 @@ func NewModule(
 	keyName string,
 	chainID string,
 ) (Module, error) {
-	return newModule(conn, authmodule, txmodule, kr, keyName, chainID)
+	return newModuleWithHelper(conn, authmodule, txmodule, &txmod.TxHelperConfig{
+		ChainID: chainID,
+		Keyring: kr,
+		KeyName: keyName,
+	})
+}
+
+// NewModuleWithTxHelperConfig creates a new audit_msg module instance with an
+// explicit TxHelper configuration. Zero-valued fields in cfg fall back to
+// package defaults.
+func NewModuleWithTxHelperConfig(
+	conn *grpc.ClientConn,
+	authmodule auth.Module,
+	txmodule txmod.Module,
+	cfg *txmod.TxHelperConfig,
+) (Module, error) {
+	return newModuleWithHelper(conn, authmodule, txmodule, cfg)
 }

--- a/pkg/lumera/modules/supernode_msg/impl.go
+++ b/pkg/lumera/modules/supernode_msg/impl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/auth"
 	snquery "github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/supernode"
 	txmod "github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/tx"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"google.golang.org/grpc"
@@ -24,15 +23,14 @@ type module struct {
 	mu       sync.Mutex
 }
 
-// newModule creates a new supernode_msg module instance.
-func newModule(
+// newModuleWithHelper creates a new supernode_msg module instance using the
+// supplied TxHelperConfig (normalized by tx.NewTxHelper).
+func newModuleWithHelper(
 	conn *grpc.ClientConn,
 	authmodule auth.Module,
 	txmodule txmod.Module,
 	supernodeQuery snquery.Module,
-	kr keyring.Keyring,
-	keyName string,
-	chainID string,
+	cfg *txmod.TxHelperConfig,
 ) (Module, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("connection cannot be nil")
@@ -46,20 +44,23 @@ func newModule(
 	if supernodeQuery == nil {
 		return nil, fmt.Errorf("supernode query module cannot be nil")
 	}
-	if kr == nil {
+	if cfg == nil {
+		return nil, fmt.Errorf("tx helper config cannot be nil")
+	}
+	if cfg.Keyring == nil {
 		return nil, fmt.Errorf("keyring cannot be nil")
 	}
-	if strings.TrimSpace(keyName) == "" {
+	if strings.TrimSpace(cfg.KeyName) == "" {
 		return nil, fmt.Errorf("key name cannot be empty")
 	}
-	if strings.TrimSpace(chainID) == "" {
+	if strings.TrimSpace(cfg.ChainID) == "" {
 		return nil, fmt.Errorf("chain ID cannot be empty")
 	}
 
 	return &module{
 		client:   sntypes.NewMsgClient(conn),
 		query:    supernodeQuery,
-		txHelper: txmod.NewTxHelperWithDefaults(authmodule, txmodule, chainID, keyName, kr),
+		txHelper: txmod.NewTxHelper(authmodule, txmodule, cfg),
 	}, nil
 }
 

--- a/pkg/lumera/modules/supernode_msg/interface.go
+++ b/pkg/lumera/modules/supernode_msg/interface.go
@@ -23,7 +23,8 @@ type Module interface {
 }
 
 // NewModule constructs a supernode_msg Module using the shared auth and tx
-// modules, the supernode query module, and keyring configuration.
+// modules, the supernode query module, and keyring configuration. Uses default
+// TxHelper settings (see tx.DefaultGas* constants).
 func NewModule(
 	conn *grpc.ClientConn,
 	authmod auth.Module,
@@ -33,5 +34,21 @@ func NewModule(
 	keyName string,
 	chainID string,
 ) (Module, error) {
-	return newModule(conn, authmod, txmod, supernodeQuery, kr, keyName, chainID)
+	return newModuleWithHelper(conn, authmod, txmod, supernodeQuery, &tx.TxHelperConfig{
+		ChainID: chainID,
+		Keyring: kr,
+		KeyName: keyName,
+	})
+}
+
+// NewModuleWithTxHelperConfig constructs a supernode_msg Module with explicit TxHelper
+// configuration. Zero-valued fields in cfg fall back to package defaults.
+func NewModuleWithTxHelperConfig(
+	conn *grpc.ClientConn,
+	authmod auth.Module,
+	txmod tx.Module,
+	supernodeQuery supernode.Module,
+	cfg *tx.TxHelperConfig,
+) (Module, error) {
+	return newModuleWithHelper(conn, authmod, txmod, supernodeQuery, cfg)
 }

--- a/pkg/lumera/modules/tx/execute_oog_integration_test.go
+++ b/pkg/lumera/modules/tx/execute_oog_integration_test.go
@@ -1,0 +1,261 @@
+package tx
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// ---------------------------------------------------------------------------
+// Stubs for TxHelper.ExecuteTransaction integration test.
+//
+// We want to prove end-to-end that the OOG-retry path is actually wired into
+// the public API that every msg module (action_msg / supernode_msg / audit_msg)
+// uses — not just the inner executeWithOOGRetry helper.
+// ---------------------------------------------------------------------------
+
+// stubAuthModule implements auth.Module just enough for TxHelper.ExecuteTransaction
+// to fetch initial account info.
+type stubAuthModule struct {
+	addr string
+	seq  uint64
+	num  uint64
+}
+
+func (s *stubAuthModule) AccountInfoByAddress(_ context.Context, _ string) (*authtypes.QueryAccountInfoResponse, error) {
+	return &authtypes.QueryAccountInfoResponse{
+		Info: &authtypes.BaseAccount{
+			Address:       s.addr,
+			AccountNumber: s.num,
+			Sequence:      s.seq,
+		},
+	}, nil
+}
+
+func (s *stubAuthModule) AccountByAddress(_ context.Context, _ string) (types.AccountI, error) {
+	return nil, fmt.Errorf("not implemented in stub")
+}
+
+func (s *stubAuthModule) Verify(_ context.Context, _ string, _, _ []byte) error { return nil }
+
+// scenarioTxModule is a test double for tx.Module that records every
+// ProcessTransaction call and can be scripted to return OOG for the first N
+// invocations, then succeed. All other Module methods are unused in this path.
+type scenarioTxModule struct {
+	mu sync.Mutex
+
+	// If non-zero, fail this many attempts with OOG before the first success.
+	oogAttempts int
+
+	// Records the config.GasAdjustment seen on each attempt.
+	seenAdjustments []float64
+
+	// Optional: fail with a non-OOG error instead of an OOG one.
+	nonOOGError error
+}
+
+func (s *scenarioTxModule) ProcessTransaction(_ context.Context, _ []types.Msg, _ *authtypes.BaseAccount, cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seenAdjustments = append(s.seenAdjustments, cfg.GasAdjustment)
+
+	attempt := len(s.seenAdjustments) // 1-indexed
+
+	if s.nonOOGError != nil {
+		return nil, s.nonOOGError
+	}
+
+	if attempt <= s.oogAttempts {
+		// Emulate the chain/sim returning ErrOutOfGas.
+		return nil, fmt.Errorf("tx failed: code=11 codespace=sdk height=0 gas_wanted=100000 gas_used=180000 raw_log=out of gas in location: ReadFlat; gasWanted: 100000, gasUsed: 180000")
+	}
+
+	// Success.
+	return &sdktx.BroadcastTxResponse{
+		TxResponse: nil, // TxHelper only consults error + full resp pointer
+	}, nil
+}
+
+func (s *scenarioTxModule) SimulateTransaction(_ context.Context, _ []types.Msg, _ *authtypes.BaseAccount, _ *TxConfig) (*sdktx.SimulateResponse, error) {
+	return &sdktx.SimulateResponse{}, nil
+}
+
+func (s *scenarioTxModule) BuildAndSignTransaction(_ context.Context, _ []types.Msg, _ *authtypes.BaseAccount, _ uint64, _ string, _ *TxConfig) ([]byte, error) {
+	return nil, fmt.Errorf("not called in this path")
+}
+func (s *scenarioTxModule) BroadcastTransaction(_ context.Context, _ []byte) (*sdktx.BroadcastTxResponse, error) {
+	return nil, fmt.Errorf("not called in this path")
+}
+func (s *scenarioTxModule) GetTransaction(_ context.Context, _ string) (*sdktx.GetTxResponse, error) {
+	return nil, fmt.Errorf("not called in this path")
+}
+func (s *scenarioTxModule) GetTxsEvent(_ context.Context, _ string, _, _ uint64) (*sdktx.GetTxsEventResponse, error) {
+	return nil, fmt.Errorf("not called in this path")
+}
+func (s *scenarioTxModule) CalculateFee(_ uint64, _ *TxConfig) string { return "" }
+
+// newTestKeyring creates an in-memory keyring with a single deterministic key
+// under name `keyName`, so TxHelper can resolve the creator address.
+func newTestKeyring(t *testing.T, keyName string) (keyring.Keyring, string) {
+	t.Helper()
+	// The Cosmos SDK keyring requires a registered proto codec that knows
+	// about the crypto interfaces to serialize keys.
+	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+	kr := keyring.NewInMemory(cdc)
+
+	// Deterministic test mnemonic.
+	const mnemonic = "test test test test test test test test test test test junk"
+	record, err := kr.NewAccount(keyName, mnemonic, "", "m/44'/118'/0'/0/0", hd.Secp256k1)
+	if err != nil {
+		t.Fatalf("keyring.NewAccount: %v", err)
+	}
+	addr, err := record.GetAddress()
+	if err != nil {
+		t.Fatalf("record.GetAddress: %v", err)
+	}
+	return kr, addr.String()
+}
+
+// TestTxHelper_ExecuteTransaction_OOGRetryEscalatesAndSucceeds simulates the
+// exact production scenario requested: 1.3 is "not okay" (chain rejects with
+// ErrOutOfGas), retry escalates gas_adjustment, and the tx eventually succeeds.
+//
+// This exercises the public TxHelper.ExecuteTransaction entrypoint that is
+// used by every msg module (action_msg.FinalizeCascadeAction in particular).
+func TestTxHelper_ExecuteTransaction_OOGRetryEscalatesAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	kr, addr := newTestKeyring(t, "validator")
+	auth := &stubAuthModule{addr: addr, seq: 42, num: 7}
+
+	// Chain rejects the first two attempts with OOG; third succeeds.
+	txMod := &scenarioTxModule{oogAttempts: 2}
+
+	h := NewTxHelper(auth, txMod, &TxHelperConfig{
+		ChainID:                  "lumera-devnet-1",
+		Keyring:                  kr,
+		KeyName:                  "validator",
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 3,
+	})
+
+	resp, err := h.ExecuteTransaction(context.Background(), func(creator string) (types.Msg, error) {
+		// We don't actually broadcast — the scenarioTxModule stubs ProcessTransaction —
+		// so we can return any msg here. Use a dummy bank Send-shaped placeholder.
+		_ = creator
+		return nil, nil // nil msg is fine; ProcessTransaction stub ignores it
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTransaction: unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("ExecuteTransaction: nil response")
+	}
+
+	// The tx module must have seen exactly 3 attempts with escalating adjustments.
+	if got := len(txMod.seenAdjustments); got != 3 {
+		t.Fatalf("attempts = %d, want 3 (scenario: OOG×2 → success), seen=%v", got, txMod.seenAdjustments)
+	}
+
+	wantSeq := []float64{1.3, 1.3 * 1.3, 1.3 * 1.3 * 1.3}
+	for i, w := range wantSeq {
+		diff := txMod.seenAdjustments[i] - w
+		if diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("attempt %d: gas_adjustment = %v, want %v", i+1, txMod.seenAdjustments[i], w)
+		}
+	}
+
+	// Sequence was advanced exactly once (the successful commit).
+	if h.nextSequence != 43 {
+		t.Errorf("nextSequence = %d, want 43 (42 + 1)", h.nextSequence)
+	}
+
+	// Caller-provided config must not have been mutated by the retry loop.
+	if h.config.GasAdjustment != 1.3 {
+		t.Errorf("helper config mutated: GasAdjustment = %v, want 1.3 (untouched base)", h.config.GasAdjustment)
+	}
+}
+
+// TestTxHelper_ExecuteTransaction_OOGExhaustedSurfacesError ensures that
+// when the chain keeps returning OOG past max attempts, the caller sees
+// a clear error and the sequence is NOT advanced (no sequence hole).
+func TestTxHelper_ExecuteTransaction_OOGExhaustedSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	kr, addr := newTestKeyring(t, "validator")
+	auth := &stubAuthModule{addr: addr, seq: 100, num: 1}
+
+	// All attempts fail with OOG.
+	txMod := &scenarioTxModule{oogAttempts: 999}
+
+	h := NewTxHelper(auth, txMod, &TxHelperConfig{
+		ChainID:                  "lumera-devnet-1",
+		Keyring:                  kr,
+		KeyName:                  "validator",
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 3,
+	})
+
+	_, err := h.ExecuteTransaction(context.Background(), func(_ string) (types.Msg, error) { return nil, nil })
+	if err == nil {
+		t.Fatal("expected error after exhausting OOG retries, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of gas after 3 attempts") {
+		t.Fatalf("error should name exhaustion: %v", err)
+	}
+
+	if got := len(txMod.seenAdjustments); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+	// Sequence MUST NOT advance on exhausted OOG.
+	if h.nextSequence != 100 {
+		t.Fatalf("nextSequence = %d, want 100 (unchanged — no sequence hole)", h.nextSequence)
+	}
+}
+
+// TestTxHelper_ExecuteTransaction_NonOOGErrorBailsAtFirstAttempt ensures that
+// a non-OOG error (e.g. signature failure, unauthorized) is surfaced
+// immediately without burning extra attempts or advancing sequence.
+func TestTxHelper_ExecuteTransaction_NonOOGErrorBailsAtFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	kr, addr := newTestKeyring(t, "validator")
+	auth := &stubAuthModule{addr: addr, seq: 7, num: 1}
+
+	txMod := &scenarioTxModule{nonOOGError: fmt.Errorf("tx failed: code=4 codespace=sdk raw_log=unauthorized")}
+
+	h := NewTxHelper(auth, txMod, &TxHelperConfig{
+		ChainID:                  "lumera-devnet-1",
+		Keyring:                  kr,
+		KeyName:                  "validator",
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 5,
+	})
+
+	_, err := h.ExecuteTransaction(context.Background(), func(_ string) (types.Msg, error) { return nil, nil })
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Fatalf("want unauthorized, got: %v", err)
+	}
+	if got := len(txMod.seenAdjustments); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (non-OOG must not retry via OOG loop)", got)
+	}
+	if h.nextSequence != 7 {
+		t.Fatalf("nextSequence advanced on non-OOG failure: %d, want 7", h.nextSequence)
+	}
+}

--- a/pkg/lumera/modules/tx/helper.go
+++ b/pkg/lumera/modules/tx/helper.go
@@ -48,27 +48,35 @@ type TxHelper struct {
 
 // TxHelperConfig holds configuration for creating a TxHelper
 type TxHelperConfig struct {
-	ChainID       string
-	Keyring       keyring.Keyring
-	KeyName       string
-	GasLimit      uint64
-	GasAdjustment float64
-	GasPadding    uint64
-	FeeDenom      string
-	GasPrice      string
+	ChainID                  string
+	Keyring                  keyring.Keyring
+	KeyName                  string
+	GasLimit                 uint64
+	GasAdjustment            float64
+	GasAdjustmentMultiplier  float64
+	GasAdjustmentMaxAttempts int
+	GasPadding               uint64
+	FeeDenom                 string
+	GasPrice                 string
 }
 
-// NewTxHelper creates a new transaction helper with the given configuration
+// NewTxHelper creates a new transaction helper with the given configuration.
+// Any zero-valued field in config falls back to the package-level Default* value,
+// so callers can pass partially-populated configs.
 func NewTxHelper(authmod auth.Module, txmod Module, config *TxHelperConfig) *TxHelper {
+	applied := applyTxHelperDefaults(config)
+
 	txConfig := &TxConfig{
-		ChainID:       config.ChainID,
-		Keyring:       config.Keyring,
-		KeyName:       config.KeyName,
-		GasLimit:      config.GasLimit,
-		GasAdjustment: config.GasAdjustment,
-		GasPadding:    config.GasPadding,
-		FeeDenom:      config.FeeDenom,
-		GasPrice:      config.GasPrice,
+		ChainID:                  applied.ChainID,
+		Keyring:                  applied.Keyring,
+		KeyName:                  applied.KeyName,
+		GasLimit:                 applied.GasLimit,
+		GasAdjustment:            applied.GasAdjustment,
+		GasAdjustmentMultiplier:  applied.GasAdjustmentMultiplier,
+		GasAdjustmentMaxAttempts: applied.GasAdjustmentMaxAttempts,
+		GasPadding:               applied.GasPadding,
+		FeeDenom:                 applied.FeeDenom,
+		GasPrice:                 applied.GasPrice,
 	}
 
 	return &TxHelper{
@@ -78,20 +86,60 @@ func NewTxHelper(authmod auth.Module, txmod Module, config *TxHelperConfig) *TxH
 	}
 }
 
-// NewTxHelperWithDefaults creates a new transaction helper with default configuration
+// NewTxHelperWithDefaults creates a new transaction helper with default configuration.
+// Preserved for backward compatibility with callers that only know chainID/keyName/keyring.
 func NewTxHelperWithDefaults(authmod auth.Module, txmod Module, chainID, keyName string, kr keyring.Keyring) *TxHelper {
-	config := &TxHelperConfig{
-		ChainID:       chainID,
-		Keyring:       kr,
-		KeyName:       keyName,
-		GasLimit:      DefaultGasLimit,
-		GasAdjustment: DefaultGasAdjustment,
-		GasPadding:    DefaultGasPadding,
-		FeeDenom:      DefaultFeeDenom,
-		GasPrice:      DefaultGasPrice,
-	}
+	return NewTxHelper(authmod, txmod, &TxHelperConfig{
+		ChainID: chainID,
+		Keyring: kr,
+		KeyName: keyName,
+	})
+}
 
-	return NewTxHelper(authmod, txmod, config)
+// applyTxHelperDefaults fills zero-valued fields in cfg with package defaults
+// and returns a new, fully-populated config. cfg itself is not mutated.
+func applyTxHelperDefaults(cfg *TxHelperConfig) TxHelperConfig {
+	if cfg == nil {
+		cfg = &TxHelperConfig{}
+	}
+	out := *cfg
+	if out.GasLimit == 0 {
+		out.GasLimit = DefaultGasLimit
+	}
+	if out.GasAdjustment <= 0 {
+		out.GasAdjustment = DefaultGasAdjustment
+	}
+	if out.GasAdjustmentMultiplier <= 1.0 {
+		// Must be strictly >1 for escalation to do anything.
+		out.GasAdjustmentMultiplier = DefaultGasAdjustmentMultiplier
+	}
+	if out.GasAdjustmentMaxAttempts <= 0 {
+		out.GasAdjustmentMaxAttempts = DefaultGasAdjustmentMaxAttempts
+	}
+	if out.GasAdjustmentMaxAttempts > 10 {
+		// hard cap as a safety net to prevent runaway fee spend.
+		out.GasAdjustmentMaxAttempts = 10
+	}
+	if out.GasPadding == 0 {
+		out.GasPadding = DefaultGasPadding
+	}
+	if strings.TrimSpace(out.FeeDenom) == "" {
+		out.FeeDenom = DefaultFeeDenom
+	}
+	if strings.TrimSpace(out.GasPrice) == "" {
+		out.GasPrice = DefaultGasPrice
+	}
+	return out
+}
+
+// cloneTxConfig returns a shallow copy safe for per-attempt mutation.
+// Keyring is interface-valued; we share the pointer (read-only usage).
+func cloneTxConfig(c *TxConfig) *TxConfig {
+	if c == nil {
+		return nil
+	}
+	copy := *c
+	return &copy
 }
 
 func (h *TxHelper) ExecuteTransaction(
@@ -141,8 +189,16 @@ func (h *TxHelper) ExecuteTransaction(
 			Address:       creator,
 		}
 
-		// Run full tx flow
-		resp, err := h.ExecuteTransactionWithMsgs(ctx, []types.Msg{msg}, accountInfo)
+		// Run the inner attempt with OOG-retry escalation on gas_adjustment.
+		// Sequence is *not* bumped between OOG retries because a SYNC-rejected
+		// CheckTx (the OOG path we detect here) does not consume the sequence.
+		resp, err := executeWithOOGRetry(
+			ctx,
+			h.config,
+			func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+				return h.txmod.ProcessTransaction(ctx, []types.Msg{msg}, accountInfo, cfg)
+			},
+		)
 		if err == nil {
 			h.nextSequence++
 			return resp, nil
@@ -185,6 +241,94 @@ func (h *TxHelper) ExecuteTransaction(
 	}
 
 	return nil, fmt.Errorf("unreachable state in ExecuteTransaction")
+}
+
+// executeWithOOGRetry runs fn with progressively larger GasAdjustment on
+// out-of-gas errors. cfg is cloned per attempt so callers are unaffected by
+// the mutation of GasAdjustment. Non-OOG errors abort the loop immediately
+// (bail semantics preserved for sequence mismatch, signature errors, etc).
+//
+// Emits a structured "tx_oog_retry" log line on every retry that Datadog can
+// facet on.
+func executeWithOOGRetry(
+	ctx context.Context,
+	baseCfg *TxConfig,
+	fn func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error),
+) (*sdktx.BroadcastTxResponse, error) {
+	if baseCfg == nil {
+		return nil, fmt.Errorf("tx config cannot be nil")
+	}
+
+	maxAttempts := baseCfg.GasAdjustmentMaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = DefaultGasAdjustmentMaxAttempts
+	}
+	multiplier := baseCfg.GasAdjustmentMultiplier
+	if multiplier <= 1.0 {
+		multiplier = DefaultGasAdjustmentMultiplier
+	}
+
+	current := cloneTxConfig(baseCfg)
+	initialAdj := current.GasAdjustment
+
+	var (
+		resp *sdktx.BroadcastTxResponse
+		err  error
+	)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		resp, err = fn(current)
+		if err == nil {
+			if attempt > 1 {
+				logtrace.Info(ctx, "tx succeeded after OOG retry", logtrace.Fields{
+					"metric":                    "tx_oog_retry",
+					"attempt":                   attempt,
+					"attempts_total":            attempt,
+					"initial_gas_adjustment":    initialAdj,
+					"final_gas_adjustment":      current.GasAdjustment,
+					"gas_adjustment_multiplier": multiplier,
+					"outcome":                   "success",
+				})
+			}
+			return resp, nil
+		}
+		if !isOutOfGas(err) {
+			// Non-OOG errors are not retried here; caller may retry at a
+			// higher level (e.g. sequence-mismatch loop in ExecuteTransaction).
+			return resp, err
+		}
+		if attempt >= maxAttempts {
+			logtrace.Warn(ctx, "tx out-of-gas: max retries exhausted", logtrace.Fields{
+				"metric":                    "tx_oog_retry",
+				"attempt":                   attempt,
+				"attempts_total":            attempt,
+				"initial_gas_adjustment":    initialAdj,
+				"final_gas_adjustment":      current.GasAdjustment,
+				"gas_adjustment_multiplier": multiplier,
+				"outcome":                   "exhausted",
+				"error":                     err.Error(),
+			})
+			return resp, fmt.Errorf("out of gas after %d attempts (final gas_adjustment=%.3f): %w",
+				attempt, current.GasAdjustment, err)
+		}
+		// Escalate for next attempt. Clone to avoid mutating caller state.
+		next := cloneTxConfig(current)
+		next.GasAdjustment = current.GasAdjustment * multiplier
+		logtrace.Info(ctx, "tx out-of-gas: retrying with higher gas_adjustment", logtrace.Fields{
+			"metric":                    "tx_oog_retry",
+			"attempt":                   attempt,
+			"next_attempt":              attempt + 1,
+			"max_attempts":              maxAttempts,
+			"prev_gas_adjustment":       current.GasAdjustment,
+			"new_gas_adjustment":        next.GasAdjustment,
+			"initial_gas_adjustment":    initialAdj,
+			"gas_adjustment_multiplier": multiplier,
+			"outcome":                   "retrying",
+			"error":                     err.Error(),
+		})
+		current = next
+	}
+	// Unreachable given the loop above, but be explicit.
+	return resp, err
 }
 
 func isSequenceMismatch(err error) bool {
@@ -275,6 +419,12 @@ func (h *TxHelper) UpdateConfig(config *TxHelperConfig) {
 	}
 	if config.GasAdjustment != 0 {
 		h.config.GasAdjustment = config.GasAdjustment
+	}
+	if config.GasAdjustmentMultiplier > 1.0 {
+		h.config.GasAdjustmentMultiplier = config.GasAdjustmentMultiplier
+	}
+	if config.GasAdjustmentMaxAttempts > 0 {
+		h.config.GasAdjustmentMaxAttempts = config.GasAdjustmentMaxAttempts
 	}
 	if config.GasPadding != 0 {
 		h.config.GasPadding = config.GasPadding

--- a/pkg/lumera/modules/tx/helper.go
+++ b/pkg/lumera/modules/tx/helper.go
@@ -116,9 +116,9 @@ func applyTxHelperDefaults(cfg *TxHelperConfig) TxHelperConfig {
 	if out.GasAdjustmentMaxAttempts <= 0 {
 		out.GasAdjustmentMaxAttempts = DefaultGasAdjustmentMaxAttempts
 	}
-	if out.GasAdjustmentMaxAttempts > 10 {
+	if out.GasAdjustmentMaxAttempts > MaxGasAdjustmentAttemptsCap {
 		// hard cap as a safety net to prevent runaway fee spend.
-		out.GasAdjustmentMaxAttempts = 10
+		out.GasAdjustmentMaxAttempts = MaxGasAdjustmentAttemptsCap
 	}
 	if out.GasPadding == 0 {
 		out.GasPadding = DefaultGasPadding
@@ -362,9 +362,22 @@ func parseExpectedSequence(err error) (uint64, bool) {
 	return 0, false
 }
 
-// ExecuteTransactionWithMsgs processes a transaction with pre-created messages and account info
+// ExecuteTransactionWithMsgs processes a transaction with pre-created messages and account info.
+// Wraps the inner broadcast in executeWithOOGRetry so external callers benefit
+// from the same OOG escalation as ExecuteTransaction. Sequence-mismatch retry
+// is NOT performed here because the caller owns accountInfo; the caller is
+// responsible for refreshing it on sequence errors.
 func (h *TxHelper) ExecuteTransactionWithMsgs(ctx context.Context, msgs []types.Msg, accountInfo *authtypes.BaseAccount) (*sdktx.BroadcastTxResponse, error) {
-	return h.txmod.ProcessTransaction(ctx, msgs, accountInfo, h.config)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return executeWithOOGRetry(
+		ctx,
+		h.config,
+		func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+			return h.txmod.ProcessTransaction(ctx, msgs, accountInfo, cfg)
+		},
+	)
 }
 
 // GetCreatorAddress returns the creator address for the configured key
@@ -424,6 +437,11 @@ func (h *TxHelper) UpdateConfig(config *TxHelperConfig) {
 		h.config.GasAdjustmentMultiplier = config.GasAdjustmentMultiplier
 	}
 	if config.GasAdjustmentMaxAttempts > 0 {
+		if config.GasAdjustmentMaxAttempts > MaxGasAdjustmentAttemptsCap {
+			// hard cap mirrors applyTxHelperDefaults — prevents runtime
+			// reconfiguration from bypassing the fee-runaway safety net.
+			config.GasAdjustmentMaxAttempts = MaxGasAdjustmentAttemptsCap
+		}
 		h.config.GasAdjustmentMaxAttempts = config.GasAdjustmentMaxAttempts
 	}
 	if config.GasPadding != 0 {

--- a/pkg/lumera/modules/tx/helper_test.go
+++ b/pkg/lumera/modules/tx/helper_test.go
@@ -1,8 +1,15 @@
 package tx
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 func TestIsSequenceMismatch(t *testing.T) {
@@ -63,5 +70,308 @@ func TestParseExpectedSequence(t *testing.T) {
 
 	if _, ok := parseExpectedSequence(nil); ok {
 		t.Fatalf("parseExpectedSequence() unexpectedly matched nil error")
+	}
+}
+
+// --- Gas-adjustment default & defaults application ---------------------------
+
+func TestDefaultGasAdjustmentIs1_3(t *testing.T) {
+	t.Parallel()
+	if DefaultGasAdjustment != 1.3 {
+		t.Fatalf("DefaultGasAdjustment = %v, want 1.3 (see Notion: SN Gas used for Finalize tx is too high)", DefaultGasAdjustment)
+	}
+	if DefaultGasAdjustmentMultiplier <= 1.0 {
+		t.Fatalf("DefaultGasAdjustmentMultiplier = %v, must be > 1.0", DefaultGasAdjustmentMultiplier)
+	}
+	if DefaultGasAdjustmentMaxAttempts <= 0 {
+		t.Fatalf("DefaultGasAdjustmentMaxAttempts = %v, must be > 0", DefaultGasAdjustmentMaxAttempts)
+	}
+}
+
+func TestApplyTxHelperDefaults_ZeroValuesUseDefaults(t *testing.T) {
+	t.Parallel()
+	got := applyTxHelperDefaults(&TxHelperConfig{
+		ChainID: "x",
+		KeyName: "k",
+	})
+	if got.GasAdjustment != DefaultGasAdjustment {
+		t.Errorf("GasAdjustment = %v, want %v", got.GasAdjustment, DefaultGasAdjustment)
+	}
+	if got.GasAdjustmentMultiplier != DefaultGasAdjustmentMultiplier {
+		t.Errorf("GasAdjustmentMultiplier = %v, want %v", got.GasAdjustmentMultiplier, DefaultGasAdjustmentMultiplier)
+	}
+	if got.GasAdjustmentMaxAttempts != DefaultGasAdjustmentMaxAttempts {
+		t.Errorf("GasAdjustmentMaxAttempts = %v, want %v", got.GasAdjustmentMaxAttempts, DefaultGasAdjustmentMaxAttempts)
+	}
+	if got.GasPadding != DefaultGasPadding {
+		t.Errorf("GasPadding = %v, want %v", got.GasPadding, DefaultGasPadding)
+	}
+	if got.FeeDenom != DefaultFeeDenom {
+		t.Errorf("FeeDenom = %v, want %v", got.FeeDenom, DefaultFeeDenom)
+	}
+	if got.GasPrice != DefaultGasPrice {
+		t.Errorf("GasPrice = %v, want %v", got.GasPrice, DefaultGasPrice)
+	}
+	if got.GasLimit != DefaultGasLimit {
+		t.Errorf("GasLimit = %v, want %v", got.GasLimit, DefaultGasLimit)
+	}
+}
+
+func TestApplyTxHelperDefaults_PreservesOperatorValues(t *testing.T) {
+	t.Parallel()
+	got := applyTxHelperDefaults(&TxHelperConfig{
+		ChainID:                  "x",
+		KeyName:                  "k",
+		GasAdjustment:            1.1,
+		GasAdjustmentMultiplier:  2.0,
+		GasAdjustmentMaxAttempts: 5,
+		GasPadding:               99,
+		FeeDenom:                 "ulume",
+		GasPrice:                 "0.050",
+	})
+	if got.GasAdjustment != 1.1 {
+		t.Errorf("GasAdjustment = %v, want 1.1", got.GasAdjustment)
+	}
+	if got.GasAdjustmentMultiplier != 2.0 {
+		t.Errorf("GasAdjustmentMultiplier = %v, want 2.0", got.GasAdjustmentMultiplier)
+	}
+	if got.GasAdjustmentMaxAttempts != 5 {
+		t.Errorf("GasAdjustmentMaxAttempts = %v, want 5", got.GasAdjustmentMaxAttempts)
+	}
+	if got.GasPadding != 99 {
+		t.Errorf("GasPadding = %v, want 99", got.GasPadding)
+	}
+	if got.GasPrice != "0.050" {
+		t.Errorf("GasPrice = %v, want 0.050", got.GasPrice)
+	}
+}
+
+func TestApplyTxHelperDefaults_CapsMaxAttempts(t *testing.T) {
+	t.Parallel()
+	got := applyTxHelperDefaults(&TxHelperConfig{
+		ChainID:                  "x",
+		KeyName:                  "k",
+		GasAdjustmentMaxAttempts: 9999,
+	})
+	if got.GasAdjustmentMaxAttempts != 10 {
+		t.Fatalf("GasAdjustmentMaxAttempts = %d, want capped to 10", got.GasAdjustmentMaxAttempts)
+	}
+}
+
+// --- isOutOfGas detection -----------------------------------------------------
+
+func TestIsOutOfGas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "simulation out of gas string",
+			err:  fmt.Errorf("simulation failed: simulation error: rpc error: code = Unknown desc = out of gas in location: ReadFlat; gasWanted: 100000, gasUsed: 180000"),
+			want: true,
+		},
+		{
+			name: "broadcast code=11 codespace=sdk",
+			err:  fmt.Errorf("tx failed: code=11 codespace=sdk height=0 gas_wanted=100000 gas_used=180000 raw_log=out of gas in location"),
+			want: true,
+		},
+		{
+			name: "broadcast mentions out of gas in raw_log only",
+			err:  fmt.Errorf("tx failed: code=11 codespace=sdk raw_log=out of gas"),
+			want: true,
+		},
+		{
+			name: "unrelated sequence mismatch",
+			err:  fmt.Errorf("account sequence mismatch, expected 10, got 9"),
+			want: false,
+		},
+		{
+			name: "unrelated code=11 but wrong codespace",
+			err:  fmt.Errorf("code=11 codespace=action height=0 gas_wanted=0 gas_used=0 raw_log=some other failure"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isOutOfGas(tt.err); got != tt.want {
+				t.Fatalf("isOutOfGas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- executeWithOOGRetry: retry escalation behavior --------------------------
+
+// oogErr returns a canonical OOG error string.
+var oogErr = fmt.Errorf("tx failed: code=11 codespace=sdk raw_log=out of gas")
+
+func TestExecuteWithOOGRetry_SuccessOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+	base := &TxConfig{
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 3,
+	}
+	var attempts int32
+	resp, err := executeWithOOGRetry(context.Background(), base, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		atomic.AddInt32(&attempts, 1)
+		if cfg.GasAdjustment != 1.3 {
+			t.Fatalf("first attempt gas_adjustment = %v, want 1.3", cfg.GasAdjustment)
+		}
+		return &sdktx.BroadcastTxResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	// Base config must not have been mutated.
+	if base.GasAdjustment != 1.3 {
+		t.Fatalf("base GasAdjustment mutated: %v", base.GasAdjustment)
+	}
+}
+
+func TestExecuteWithOOGRetry_EscalatesAndSucceeds(t *testing.T) {
+	t.Parallel()
+	base := &TxConfig{
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 4,
+	}
+	var seen []float64
+	_, err := executeWithOOGRetry(context.Background(), base, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		seen = append(seen, cfg.GasAdjustment)
+		// Fail with OOG for the first two attempts, succeed on the third.
+		if len(seen) < 3 {
+			return nil, oogErr
+		}
+		return &sdktx.BroadcastTxResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("saw %d attempts, want 3 (gas values: %v)", len(seen), seen)
+	}
+	// Multiplicative: 1.3, 1.3*1.3, 1.3*1.3*1.3.
+	wantSeq := []float64{1.3, 1.3 * 1.3, 1.3 * 1.3 * 1.3}
+	for i, w := range wantSeq {
+		if diff := seen[i] - w; diff > 1e-9 || diff < -1e-9 {
+			t.Errorf("attempt %d: gas_adjustment=%v, want %v", i+1, seen[i], w)
+		}
+	}
+	// Base config must not have been mutated by the loop.
+	if base.GasAdjustment != 1.3 {
+		t.Fatalf("base GasAdjustment mutated: %v", base.GasAdjustment)
+	}
+}
+
+func TestExecuteWithOOGRetry_NonOOGBailsImmediately(t *testing.T) {
+	t.Parallel()
+	base := &TxConfig{
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 5,
+	}
+	nonOOG := fmt.Errorf("tx failed: code=4 codespace=sdk raw_log=unauthorized")
+
+	var attempts int32
+	_, err := executeWithOOGRetry(context.Background(), base, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, nonOOG
+	})
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Fatalf("want unauthorized error, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (non-OOG must bail immediately)", got)
+	}
+}
+
+func TestExecuteWithOOGRetry_HonoursMaxAttempts(t *testing.T) {
+	t.Parallel()
+	base := &TxConfig{
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 3,
+	}
+	var attempts int32
+	_, err := executeWithOOGRetry(context.Background(), base, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		atomic.AddInt32(&attempts, 1)
+		return nil, oogErr
+	})
+	if err == nil {
+		t.Fatal("expected error after max attempts, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of gas after 3 attempts") {
+		t.Fatalf("error message missing attempt count: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+}
+
+func TestExecuteWithOOGRetry_CloneIsolatesConfigMutation(t *testing.T) {
+	t.Parallel()
+	base := &TxConfig{
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  2.0,
+		GasAdjustmentMaxAttempts: 3,
+	}
+	_, _ = executeWithOOGRetry(context.Background(), base, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		cfg.GasAdjustment = 999.0 // mutate clone
+		return nil, oogErr
+	})
+	if base.GasAdjustment != 1.3 {
+		t.Fatalf("base config mutated: GasAdjustment = %v", base.GasAdjustment)
+	}
+	if base.GasAdjustmentMaxAttempts != 3 {
+		t.Fatalf("base GasAdjustmentMaxAttempts mutated: %v", base.GasAdjustmentMaxAttempts)
+	}
+}
+
+func TestExecuteWithOOGRetry_NilBaseReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := executeWithOOGRetry(context.Background(), nil, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("expected error on nil base cfg")
+	}
+}
+
+// --- smoke: fn signature requires ctx + account usable -----------------------
+// This asserts executeWithOOGRetry does not depend on any undeclared globals.
+func TestExecuteWithOOGRetry_CallableSmokeUsesAccountInfo(t *testing.T) {
+	t.Parallel()
+	acc := &authtypes.BaseAccount{Address: "lumera1abc", Sequence: 7}
+	msgs := []types.Msg{}
+	_ = acc
+	_ = msgs
+
+	base := &TxConfig{
+		GasAdjustment:            1.3,
+		GasAdjustmentMultiplier:  1.3,
+		GasAdjustmentMaxAttempts: 1,
+	}
+	_, err := executeWithOOGRetry(context.Background(), base, func(cfg *TxConfig) (*sdktx.BroadcastTxResponse, error) {
+		return &sdktx.BroadcastTxResponse{}, nil
+	})
+	if err != nil {
+		t.Fatalf("smoke: %v", err)
 	}
 }

--- a/pkg/lumera/modules/tx/helper_test.go
+++ b/pkg/lumera/modules/tx/helper_test.go
@@ -354,6 +354,88 @@ func TestExecuteWithOOGRetry_NilBaseReturnsError(t *testing.T) {
 	}
 }
 
+// --- UpdateConfig safety: hard cap on GasAdjustmentMaxAttempts ---------------
+// Regression: UpdateConfig previously accepted any positive value, bypassing
+// the applyTxHelperDefaults() cap and allowing fee runaway via runtime reconfig.
+func TestTxHelper_UpdateConfig_CapsMaxAttempts(t *testing.T) {
+	t.Parallel()
+	h := &TxHelper{config: &TxConfig{GasAdjustmentMaxAttempts: 3}}
+	h.UpdateConfig(&TxHelperConfig{GasAdjustmentMaxAttempts: 9999})
+	if h.config.GasAdjustmentMaxAttempts != MaxGasAdjustmentAttemptsCap {
+		t.Fatalf("UpdateConfig accepted un-capped MaxAttempts = %d, want %d",
+			h.config.GasAdjustmentMaxAttempts, MaxGasAdjustmentAttemptsCap)
+	}
+}
+
+func TestTxHelper_UpdateConfig_PreservesReasonableMaxAttempts(t *testing.T) {
+	t.Parallel()
+	h := &TxHelper{config: &TxConfig{GasAdjustmentMaxAttempts: 3}}
+	h.UpdateConfig(&TxHelperConfig{GasAdjustmentMaxAttempts: 5})
+	if h.config.GasAdjustmentMaxAttempts != 5 {
+		t.Fatalf("UpdateConfig dropped reasonable value: got %d, want 5",
+			h.config.GasAdjustmentMaxAttempts)
+	}
+}
+
+// --- ExecuteTransactionWithMsgs: OOG retry parity with ExecuteTransaction ----
+// Regression: the pre-built-messages path previously called ProcessTransaction
+// directly, bypassing the OOG escalation. External SDK consumers (sdk-go)
+// relying on this entry point must get the same behavior.
+func TestExecuteTransactionWithMsgs_AppliesOOGRetry(t *testing.T) {
+	t.Parallel()
+
+	mod := &scenarioTxModule{oogAttempts: 2}
+
+	h := &TxHelper{
+		txmod: mod,
+		config: &TxConfig{
+			GasAdjustment:            0.5,
+			GasAdjustmentMultiplier:  2.0,
+			GasAdjustmentMaxAttempts: 5,
+		},
+	}
+
+	acc := &authtypes.BaseAccount{Address: "lumera1abc", Sequence: 1}
+	resp, err := h.ExecuteTransactionWithMsgs(context.Background(), []types.Msg{}, acc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil resp after OOG retry")
+	}
+	if got := len(mod.seenAdjustments); got != 3 {
+		t.Fatalf("attempts = %d, want 3 (OOG retry should escalate)", got)
+	}
+	// Sanity: gas_adjustment should have escalated between attempts.
+	if !(mod.seenAdjustments[0] < mod.seenAdjustments[1] && mod.seenAdjustments[1] < mod.seenAdjustments[2]) {
+		t.Fatalf("expected escalating gas_adjustment, got %v", mod.seenAdjustments)
+	}
+}
+
+func TestExecuteTransactionWithMsgs_NonOOGBailsImmediately(t *testing.T) {
+	t.Parallel()
+
+	mod := &scenarioTxModule{nonOOGError: fmt.Errorf("signature verification failed")}
+
+	h := &TxHelper{
+		txmod: mod,
+		config: &TxConfig{
+			GasAdjustment:            1.3,
+			GasAdjustmentMultiplier:  1.3,
+			GasAdjustmentMaxAttempts: 5,
+		},
+	}
+
+	acc := &authtypes.BaseAccount{Address: "lumera1abc", Sequence: 1}
+	_, err := h.ExecuteTransactionWithMsgs(context.Background(), []types.Msg{}, acc)
+	if err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("expected non-OOG error to bubble up, got: %v", err)
+	}
+	if got := len(mod.seenAdjustments); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (non-OOG must not retry)", got)
+	}
+}
+
 // --- smoke: fn signature requires ctx + account usable -----------------------
 // This asserts executeWithOOGRetry does not depend on any undeclared globals.
 func TestExecuteWithOOGRetry_CallableSmokeUsesAccountInfo(t *testing.T) {

--- a/pkg/lumera/modules/tx/impl.go
+++ b/pkg/lumera/modules/tx/impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	"github.com/LumeraProtocol/supernode/v2/pkg/logtrace"
 	lumeracodec "github.com/LumeraProtocol/supernode/v2/pkg/lumera/codec"
@@ -20,13 +21,24 @@ import (
 
 // Default parameters
 const (
-	DefaultGasLimit      = uint64(200000)
-	DefaultGasAdjustment = float64(1.5)
-	DefaultGasPadding    = uint64(50000)
-	DefaultFeeDenom      = "ulume"
+	DefaultGasLimit uint64 = 200000
+	// DefaultGasAdjustment is the default multiplier applied to simulated gas.
+	// Lowered from 1.5 to 1.3 to reduce supernode fee over-spend. The OOG
+	// retry path in TxHelper.ExecuteTransaction will escalate this value
+	// if a broadcast/simulation actually runs out of gas.
+	DefaultGasAdjustment float64 = 1.3
+	// DefaultGasAdjustmentMultiplier is the factor applied to GasAdjustment
+	// on each OOG retry. Must be > 1.0.
+	DefaultGasAdjustmentMultiplier float64 = 1.3
+	// DefaultGasAdjustmentMaxAttempts is the total number of attempts
+	// (including the initial attempt) made before giving up on OOG.
+	// Range: [1, 10]. Default 3 gives adjustments 1.3 → 1.69 → 2.197.
+	DefaultGasAdjustmentMaxAttempts int    = 3
+	DefaultGasPadding               uint64 = 50000
+	DefaultFeeDenom                 string = "ulume"
 	// DefaultGasPrice is the default min gas price in denom units (e.g., ulume)
 	// Set to 0.025 to match chain defaults where applicable.
-	DefaultGasPrice = "0.025"
+	DefaultGasPrice string = "0.025"
 )
 
 // module implements the Module interface
@@ -307,7 +319,8 @@ func (m *module) ProcessTransaction(ctx context.Context, msgs []types.Msg, accou
 	// Step 3: Calculate fee based on adjusted gas
 	fee := m.CalculateFee(gasToUse, config)
 
-	logtrace.Debug(ctx, fmt.Sprintf("using simulated gas and calculated fee | simulatedGas=%d gasToUse=%d fee=%s", simulatedGasUsed, gasToUse, fee), nil)
+	logtrace.Debug(ctx, fmt.Sprintf("using simulated gas and calculated fee | simulatedGas=%d gasToUse=%d fee=%s gas_adjustment=%.3f gas_padding=%d",
+		simulatedGasUsed, gasToUse, fee, config.GasAdjustment, config.GasPadding), nil)
 
 	// Step 4: Build and sign transaction
 	txBytes, err := m.BuildAndSignTransaction(ctx, msgs, accountInfo, gasToUse, fee, config)
@@ -352,4 +365,25 @@ func validateTxConfig(config *TxConfig) error {
 		}
 	}
 	return nil
+}
+
+// isOutOfGas detects whether err represents a Cosmos SDK "out of gas" failure
+// observable from simulation or CheckTx (SYNC broadcast) paths.
+//
+// Matches both:
+//   - sdkerrors.ErrOutOfGas (code=11 codespace=sdk) surfaced from BroadcastTransaction
+//   - raw "out of gas" strings appearing in simulation/ante-handler errors
+func isOutOfGas(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "out of gas") {
+		return true
+	}
+	// Cosmos SDK ErrOutOfGas: code=11 codespace=sdk
+	if strings.Contains(msg, "code=11") && strings.Contains(msg, "codespace=sdk") {
+		return true
+	}
+	return false
 }

--- a/pkg/lumera/modules/tx/impl.go
+++ b/pkg/lumera/modules/tx/impl.go
@@ -33,9 +33,13 @@ const (
 	// DefaultGasAdjustmentMaxAttempts is the total number of attempts
 	// (including the initial attempt) made before giving up on OOG.
 	// Range: [1, 10]. Default 3 gives adjustments 1.3 → 1.69 → 2.197.
-	DefaultGasAdjustmentMaxAttempts int    = 3
-	DefaultGasPadding               uint64 = 50000
-	DefaultFeeDenom                 string = "ulume"
+	DefaultGasAdjustmentMaxAttempts int = 3
+	// MaxGasAdjustmentAttemptsCap is a hard safety cap on the number of OOG
+	// retries. Even if an operator (or a runtime reconfiguration) sets a
+	// larger value, we never exceed this — protects against fee runaway.
+	MaxGasAdjustmentAttemptsCap int    = 10
+	DefaultGasPadding           uint64 = 50000
+	DefaultFeeDenom             string = "ulume"
 	// DefaultGasPrice is the default min gas price in denom units (e.g., ulume)
 	// Set to 0.025 to match chain defaults where applicable.
 	DefaultGasPrice string = "0.025"

--- a/pkg/lumera/modules/tx/interface.go
+++ b/pkg/lumera/modules/tx/interface.go
@@ -11,16 +11,23 @@ import (
 	"google.golang.org/grpc"
 )
 
-// TxConfig holds configuration for transaction operations
+// TxConfig holds configuration for transaction operations.
+//
+// GasAdjustment / GasAdjustmentMultiplier / GasAdjustmentMaxAttempts together
+// drive the OOG-retry escalation policy inside TxHelper.ExecuteTransaction:
+// each OOG failure re-runs ProcessTransaction with
+// gas_adjustment *= GasAdjustmentMultiplier, up to GasAdjustmentMaxAttempts total attempts.
 type TxConfig struct {
-	ChainID       string
-	Keyring       keyring.Keyring
-	KeyName       string // Name of the key to use for signing
-	GasLimit      uint64
-	GasAdjustment float64
-	GasPadding    uint64
-	FeeDenom      string
-	GasPrice      string
+	ChainID                  string
+	Keyring                  keyring.Keyring
+	KeyName                  string // Name of the key to use for signing
+	GasLimit                 uint64
+	GasAdjustment            float64
+	GasAdjustmentMultiplier  float64 // per-retry multiplier applied to GasAdjustment on OOG (>1.0)
+	GasAdjustmentMaxAttempts int     // total attempts (including the initial one) before giving up on OOG
+	GasPadding               uint64
+	FeeDenom                 string
+	GasPrice                 string
 }
 
 // Module defines the interface for transaction-related operations

--- a/supernode/cmd/start.go
+++ b/supernode/cmd/start.go
@@ -349,7 +349,20 @@ func initLumeraClient(ctx context.Context, config *config.Config, kr cKeyring.Ke
 		return nil, fmt.Errorf("config is nil")
 	}
 
-	lumeraConfig, err := lumera.NewConfig(config.LumeraClientConfig.GRPCAddr, config.LumeraClientConfig.ChainID, config.SupernodeConfig.KeyName, kr)
+	lumeraConfig, err := lumera.NewConfig(
+		config.LumeraClientConfig.GRPCAddr,
+		config.LumeraClientConfig.ChainID,
+		config.SupernodeConfig.KeyName,
+		kr,
+		lumera.TxOptions{
+			GasAdjustment:            config.LumeraClientConfig.GasAdjustment,
+			GasAdjustmentMultiplier:  config.LumeraClientConfig.GasAdjustmentMultiplier,
+			GasAdjustmentMaxAttempts: config.LumeraClientConfig.GasAdjustmentMaxAttempts,
+			GasPadding:               config.LumeraClientConfig.GasPadding,
+			GasPrice:                 config.LumeraClientConfig.GasPrice,
+			FeeDenom:                 config.LumeraClientConfig.FeeDenom,
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Lumera config: %w", err)
 	}

--- a/supernode/config/config.go
+++ b/supernode/config/config.go
@@ -37,6 +37,24 @@ type P2PConfig struct {
 type LumeraClientConfig struct {
 	GRPCAddr string `yaml:"grpc_addr"`
 	ChainID  string `yaml:"chain_id"`
+
+	// Optional tx/gas tuning knobs. Zero values fall back to the SDK
+	// defaults (see pkg/lumera/modules/tx.Default* constants).
+	//
+	// gas_adjustment           multiplier applied to simulated gas
+	//                          (default 1.3)
+	// gas_adjustment_multiplier per-retry multiplier on OOG (default 1.3)
+	// gas_adjustment_max_attempts total attempts on OOG (default 3, cap 10)
+	// gas_padding              extra gas added on top of adjusted gas
+	//                          (default 50000)
+	// gas_price                "0.025" or "0.025ulume" (default "0.025")
+	// fee_denom                coin denom for fees (default "ulume")
+	GasAdjustment            float64 `yaml:"gas_adjustment,omitempty"`
+	GasAdjustmentMultiplier  float64 `yaml:"gas_adjustment_multiplier,omitempty"`
+	GasAdjustmentMaxAttempts int     `yaml:"gas_adjustment_max_attempts,omitempty"`
+	GasPadding               uint64  `yaml:"gas_padding,omitempty"`
+	GasPrice                 string  `yaml:"gas_price,omitempty"`
+	FeeDenom                 string  `yaml:"fee_denom,omitempty"`
 }
 
 type RaptorQConfig struct {

--- a/supernode/config/config_gas_test.go
+++ b/supernode/config/config_gas_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadConfig_GasTuningKnobs verifies the new optional tx/gas YAML knobs
+// round-trip correctly through LoadConfig and are exposed on LumeraClientConfig.
+func TestLoadConfig_GasTuningKnobs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supernode.yml")
+
+	const yamlBody = `
+supernode:
+  key_name: test-key
+  identity: lumera1identity000000000000000000000000000000
+  host: 0.0.0.0
+  port: 4444
+keyring:
+  backend: test
+  dir: keys
+p2p:
+  port: 4445
+  data_dir: data/p2p
+lumera:
+  grpc_addr: localhost:9090
+  chain_id: testing
+  gas_adjustment: 1.15
+  gas_adjustment_multiplier: 1.5
+  gas_adjustment_max_attempts: 4
+  gas_padding: 123456
+  gas_price: "0.030"
+  fee_denom: ulume
+raptorq:
+  files_dir: raptorq_files
+storage_challenge:
+  enabled: true
+  poll_interval_ms: 1000
+  submit_evidence: false
+`
+	if err := os.WriteFile(path, []byte(yamlBody), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	cfg, err := LoadConfig(path, dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	got := cfg.LumeraClientConfig
+	if got.GasAdjustment != 1.15 {
+		t.Errorf("GasAdjustment = %v, want 1.15", got.GasAdjustment)
+	}
+	if got.GasAdjustmentMultiplier != 1.5 {
+		t.Errorf("GasAdjustmentMultiplier = %v, want 1.5", got.GasAdjustmentMultiplier)
+	}
+	if got.GasAdjustmentMaxAttempts != 4 {
+		t.Errorf("GasAdjustmentMaxAttempts = %v, want 4", got.GasAdjustmentMaxAttempts)
+	}
+	if got.GasPadding != 123456 {
+		t.Errorf("GasPadding = %v, want 123456", got.GasPadding)
+	}
+	if got.GasPrice != "0.030" {
+		t.Errorf("GasPrice = %q, want 0.030", got.GasPrice)
+	}
+	if got.FeeDenom != "ulume" {
+		t.Errorf("FeeDenom = %q, want ulume", got.FeeDenom)
+	}
+}
+
+// TestLoadConfig_GasTuningKnobs_ZeroMeansDefault verifies that omitting the
+// optional gas knobs yields zero values on the struct (caller falls back to
+// package defaults inside pkg/lumera/modules/tx).
+func TestLoadConfig_GasTuningKnobs_ZeroMeansDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "supernode.yml")
+
+	const yamlBody = `
+supernode:
+  key_name: test-key
+  identity: lumera1identity000000000000000000000000000000
+  host: 0.0.0.0
+  port: 4444
+keyring:
+  backend: test
+  dir: keys
+p2p:
+  port: 4445
+  data_dir: data/p2p
+lumera:
+  grpc_addr: localhost:9090
+  chain_id: testing
+raptorq:
+  files_dir: raptorq_files
+storage_challenge:
+  enabled: true
+`
+	if err := os.WriteFile(path, []byte(yamlBody), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	cfg, err := LoadConfig(path, dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	got := cfg.LumeraClientConfig
+	if got.GasAdjustment != 0 {
+		t.Errorf("GasAdjustment = %v, want 0 (omitted → default)", got.GasAdjustment)
+	}
+	if got.GasAdjustmentMultiplier != 0 {
+		t.Errorf("GasAdjustmentMultiplier = %v, want 0", got.GasAdjustmentMultiplier)
+	}
+	if got.GasAdjustmentMaxAttempts != 0 {
+		t.Errorf("GasAdjustmentMaxAttempts = %v, want 0", got.GasAdjustmentMaxAttempts)
+	}
+	if got.GasPadding != 0 {
+		t.Errorf("GasPadding = %v, want 0", got.GasPadding)
+	}
+	if got.GasPrice != "" {
+		t.Errorf("GasPrice = %q, want empty", got.GasPrice)
+	}
+	if got.FeeDenom != "" {
+		t.Errorf("FeeDenom = %q, want empty", got.FeeDenom)
+	}
+}


### PR DESCRIPTION
## Summary

Supernode was using `gas_adjustment=1.5` + `50k` padding for every outbound tx (including `MsgFinalizeAction`), inflating fee spend. This PR:

1. Lowers the default `GasAdjustment` from `1.5` → `1.3`.
2. Makes the full fee/gas tuning bundle operator-configurable via YAML.
3. Adds an OOG-retry path with **multiplicative escalation** as a safety net, so a lower default can never cause transaction failure.

Client-side only. **No chain change. No migration. No upgrade handler.**

Ref: [Notion — SN Gas used for Finalize tx is too high](https://www.notion.so/pastelnetwork/SN-Gas-used-for-Finalize-tx-is-too-high-345df11fee148011bac1fe1268c99326)

## Behavior change

**Defaults**
| Knob | Before | After |
|---|---|---|
| `GasAdjustment` | `1.5` | `1.3` |
| `GasAdjustmentMultiplier` | — | `1.3` |
| `GasAdjustmentMaxAttempts` | — | `3` (cap 10) |
| `GasPadding` | `50000` | `50000` |
| `GasPrice` | `0.025` | `0.025` |
| `FeeDenom` | `ulume` | `ulume` |

**New optional YAML** (`supernode.yml` under `lumera:`):
```yaml
lumera:
  grpc_addr: ...
  chain_id: ...
  gas_adjustment: 1.3
  gas_adjustment_multiplier: 1.3
  gas_adjustment_max_attempts: 3
  gas_padding: 50000
  gas_price: "0.025"      # or "0.025ulume"
  fee_denom: ulume
```
Omitted / zero-valued fields fall back to package defaults deterministically.

**OOG retry**
- Detects both `"out of gas"` simulation errors and `code=11 codespace=sdk` broadcast errors.
- Escalates `GasAdjustment *= Multiplier` on each retry. Default sequence: `1.3 → 1.69 → 2.197`.
- Cloned per attempt — never mutates caller/shared `TxConfig`.
- Non-OOG errors bail immediately (preserves the outer sequence-mismatch retry semantics).
- Hard-capped at 10 attempts as a safety net against fee runaway.

## Observability

Every retry emits a structured `logtrace` line that's facet-able in Datadog:
```
metric="tx_oog_retry"
outcome={retrying|success|exhausted}
attempt / max_attempts
initial_gas_adjustment / prev_gas_adjustment / new_gas_adjustment
gas_adjustment_multiplier
error
```

## Files changed

- `pkg/lumera/modules/tx/impl.go`, `helper.go`, `interface.go` — defaults, `isOutOfGas`, `executeWithOOGRetry`, `applyTxHelperDefaults`, `TxConfig`/`TxHelperConfig` extensions, retry wiring in `ExecuteTransaction`.
- `pkg/lumera/config.go`, `client.go` — `TxOptions` variadic on `NewConfig`; `Config.toTxHelperConfig()`; all three msg modules receive explicit helper config.
- `pkg/lumera/modules/{action_msg,supernode_msg,audit_msg}` — new `NewModuleWithTxHelperConfig` constructors; legacy `NewModule` preserved for backward compat.
- `supernode/config/config.go` — six new optional `LumeraClientConfig` YAML fields.
- `supernode/cmd/start.go` — propagates YAML → `lumera.NewConfig`.

## Tests

**16 new tests, all passing:**

`pkg/lumera/modules/tx/helper_test.go`:
- Default is exactly `1.3`.
- `applyTxHelperDefaults` — zero → defaults, operator values preserved, max-attempts cap honored.
- `isOutOfGas` — 6 subcases: nil / simulation string / `code=11 codespace=sdk` / raw_log-only / sequence-mismatch (false) / wrong codespace (false).
- `executeWithOOGRetry`:
  - success on first attempt
  - escalates multiplicatively and succeeds on 3rd attempt (verifies exact `1.3 → 1.69 → 2.197` sequence)
  - non-OOG errors bail immediately (single attempt)
  - max-attempts honored; final error includes attempt count
  - clone isolates caller `TxConfig` from mutation
  - nil base cfg returns error

`pkg/lumera/config_test.go`:
- `NewConfig` rejects invalid inputs (4 subcases).
- `TxOptions` propagate through `toTxHelperConfig()`.

`supernode/config/config_gas_test.go`:
- Round-trips all six new YAML keys.
- Omitted keys yield zero values (defaults applied at tx layer).

**Verification**:
- `go build ./pkg/... ./supernode/...` clean.
- `go vet ./pkg/lumera/... ./supernode/config/... ./supernode/cmd/...` clean.
- `gofmt -l` clean.
- Full `go test` sweep over `pkg/...`, `supernode/...`, `sdk/...` — 0 failures.

## Risks

- **Under-estimation.** `1.3 × simGas + 50k` is industry-standard for Cosmos SDK; retry loop covers pathological edges. Max-attempts cap at 10 prevents runaway fee spend.
- **Concurrency.** `TxHelper` already serializes via `sync.Mutex`; per-attempt `TxConfig` is cloned.
- **State-machine safety.** None — this is fee accounting only; determinism preserved.
- **API break for external `pkg/lumera` consumers.** Mitigated via variadic `TxOptions` on `NewConfig` and legacy `NewModule` constructors preserved.

## Rollout / Rollback

- Tag SN release → testnet SNs → 48h soak → mainnet.
- **No binary rollback needed**: operators can set `gas_adjustment: 1.5` in YAML if required.

## Follow-ups (not in this PR)

1. Companion PR in `lumera-tools-internal` to document the new keys in sample launch-bundle configs.
2. Datadog monitor on `metric:tx_oog_retry` post-deploy.
