### PR TITLE
feat(host_reporter): add LUMERA_SUPERNODE_DISABLE_HOST_REPORTER test affordance

### DIFF
--- a/supernode/cmd/start.go
+++ b/supernode/cmd/start.go
@@ -162,16 +162,29 @@ The supernode will connect to the Lumera network and begin participating in the 
 		// Create supernode status service with injected tracker
 		statusSvc := statusService.NewSupernodeStatusService(p2pService, lumeraClient, appConfig, tr)
 
-		hostReporter, err := hostReporterService.NewService(
-			appConfig.SupernodeConfig.Identity,
-			lumeraClient,
-			kr,
-			appConfig.SupernodeConfig.KeyName,
-			appConfig.BaseDir,
-			appConfig.GetP2PDataDir(),
-		)
-		if err != nil {
-			logtrace.Fatal(ctx, "Failed to initialize host reporter", logtrace.Fields{"error": err.Error()})
+		// Test/devnet affordance: when LUMERA_SUPERNODE_DISABLE_HOST_REPORTER=1 is set,
+		// skip starting the on-chain host_reporter service. This frees the supernode's
+		// reporter key for externally driven `MsgSubmitEpochReport` flows (e.g. the
+		// everlight devnet test scenarios) that would otherwise lose the account-sequence
+		// race against the SN's own ~5s auto-submit ticker. Production deployments must
+		// leave this unset; gated behind an env var with no config-file surface so the
+		// canonical path is unchanged.
+		var hostReporter service
+		if v := strings.TrimSpace(os.Getenv("LUMERA_SUPERNODE_DISABLE_HOST_REPORTER")); v == "1" || strings.EqualFold(v, "true") {
+			logtrace.Info(ctx, "host_reporter disabled via LUMERA_SUPERNODE_DISABLE_HOST_REPORTER", logtrace.Fields{})
+		} else {
+			hr, err := hostReporterService.NewService(
+				appConfig.SupernodeConfig.Identity,
+				lumeraClient,
+				kr,
+				appConfig.SupernodeConfig.KeyName,
+				appConfig.BaseDir,
+				appConfig.GetP2PDataDir(),
+			)
+			if err != nil {
+				logtrace.Fatal(ctx, "Failed to initialize host reporter", logtrace.Fields{"error": err.Error()})
+			}
+			hostReporter = hr
 		}
 
 		// Legacy on-chain supernode metrics reporting has been superseded by `x/audit`.
@@ -254,7 +267,10 @@ The supernode will connect to the Lumera network and begin participating in the 
 		// Start the services using the standard runner and capture exit
 		servicesErr := make(chan error, 1)
 		go func() {
-			services := []service{grpcServer, cService, p2pService, gatewayServer, hostReporter}
+			services := []service{grpcServer, cService, p2pService, gatewayServer}
+			if hostReporter != nil {
+				services = append(services, hostReporter)
+			}
 			if storageChallengeRunner != nil {
 				services = append(services, storageChallengeRunner)
 			}


### PR DESCRIPTION
## Summary

Adds an env-gated knob to disable the on-chain `host_reporter` service:

- `LUMERA_SUPERNODE_DISABLE_HOST_REPORTER=1` (or `true`) → host_reporter is not started.
- Unset / any other value → canonical behavior, host_reporter runs as today.

## Why

The everlight devnet test (`devnet/tests/everlight/everlight_test.sh` in the lumera repo) drives `MsgSubmitEpochReport` from outside the SN to exercise the STORAGE_FULL state transition (S2.3–S2.6) and anti-gaming guardrails (S5.x) as black-box state-machine tests. The SN's own `host_reporter` ticks every ~5s and auto-submits using the same reporter key — the test loses every account-sequence race and the scenarios cannot complete.

This was **not** a chain bug: epoch math is immutable-by-design, `MsgSubmitEpochReport.Creator` must be the registered SN account, and host_reporter's auto-submit (PR #284) is correct. The fix is a test affordance, not a behavior change.

## Scope

- One file (`supernode/cmd/start.go`), ~27 LOC.
- Env-var gated; no config-file surface.
- Production deployments are unaffected unless they explicitly set the var.
- `hostReporter` is now optional in the services slice; nil-guarded before append.

## Verification

Built locally, deployed in 5-validator devnet with `EVERLIGHT_TEST_TARGET=1` only on `supernova_validator_1`:

- v1 startup log: `INFO host_reporter disabled via LUMERA_SUPERNODE_DISABLE_HOST_REPORTER`
- v2–v5: host_reporter running normally (`epoch report submitted` lines flowing).
- Full `make devnet-tests-everlight` run: **PASS: 39  FAIL: 0  SKIP: 4** (skips are intentional — full-lifecycle / pre-Everlight genesis scenarios that are out of scope for the everlight feature flag).

## Risks

- None to production: when the env var is unset the code path is byte-identical to today (same `NewService` call, same fatal-on-error, same services-slice membership).
- The new `if hostReporter != nil` guard before append is a no-op in the canonical path.

## Rollback

Revert this single commit. Companion lumera-side changes (devnet compose + everlight test fixes) ship in a separate PR on the lumera repo.