### PR TITLE
fix(host-reporter): compat-map disk reports for storage full

### DIFF
--- a/supernode/host_reporter/service.go
+++ b/supernode/host_reporter/service.go
@@ -3,6 +3,7 @@ package host_reporter
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
+	sntypes "github.com/LumeraProtocol/lumera/x/supernode/v1/types"
 	"github.com/LumeraProtocol/supernode/v2/pkg/logtrace"
 	"github.com/LumeraProtocol/supernode/v2/pkg/lumera"
 	"github.com/LumeraProtocol/supernode/v2/pkg/reachability"
@@ -26,6 +28,8 @@ const (
 	defaultTickTimeout  = 30 * time.Second
 
 	maxConcurrentTargets = 8
+
+	postponeReasonAuditHostRequirements = "audit_host_requirements"
 )
 
 // Service submits one MsgSubmitEpochReport per epoch for the local supernode.
@@ -150,7 +154,16 @@ func (s *Service) tick(ctx context.Context) {
 		MemUsagePercent: 0,
 	}
 	if diskUsagePercent, ok := s.diskUsagePercent(tickCtx); ok {
-		hostReport.DiskUsagePercent = diskUsagePercent
+		reportedDiskUsagePercent, compatReason := s.auditDiskUsagePercent(tickCtx, diskUsagePercent)
+		hostReport.DiskUsagePercent = reportedDiskUsagePercent
+		if compatReason != "" {
+			logtrace.Warn(tickCtx, "audit disk usage compatibility override applied", logtrace.Fields{
+				"epoch_id":                    epochID,
+				"actual_disk_usage_percent":   diskUsagePercent,
+				"reported_disk_usage_percent": reportedDiskUsagePercent,
+				"reason":                      compatReason,
+			})
+		}
 	}
 	if cascadeBytes, ok := s.cascadeKademliaDBBytes(tickCtx); ok {
 		hostReport.CascadeKademliaDbBytes = float64(cascadeBytes)
@@ -179,6 +192,66 @@ func (s *Service) diskUsagePercent(ctx context.Context) (float64, bool) {
 		return 0, false
 	}
 	return infos[0].UsagePercent, true
+}
+
+func (s *Service) auditDiskUsagePercent(ctx context.Context, actual float64) (float64, string) {
+	if actual <= 0 || actual > 100 {
+		return actual, ""
+	}
+
+	auditParamsResp, err := s.lumera.Audit().GetParams(ctx)
+	if err != nil || auditParamsResp == nil {
+		return actual, ""
+	}
+	auditMinDiskFree := auditParamsResp.Params.MinDiskFreePercent
+	if auditMinDiskFree == 0 || auditMinDiskFree > 100 {
+		return actual, ""
+	}
+
+	supernodeParamsResp, err := s.lumera.SuperNode().GetParams(ctx)
+	if err != nil || supernodeParamsResp == nil {
+		return actual, ""
+	}
+
+	maxStorageUsage := supernodeParamsResp.Params.MaxStorageUsagePercent
+	if maxStorageUsage == 0 || maxStorageUsage >= 100 {
+		return actual, ""
+	}
+
+	auditPostponeUsage := 100 - float64(auditMinDiskFree)
+	storageFullUsage := float64(maxStorageUsage)
+	if auditPostponeUsage > storageFullUsage || actual < auditPostponeUsage {
+		return actual, ""
+	}
+
+	sn, err := s.lumera.SuperNode().GetSupernodeBySupernodeAddress(ctx, s.identity)
+	if err != nil || sn == nil {
+		return actual, ""
+	}
+
+	latestState, latestReason := latestSupernodeState(sn)
+	switch latestState {
+	case sntypes.SuperNodeStatePostponed:
+		if latestReason == "" || latestReason == postponeReasonAuditHostRequirements {
+			return auditPostponeUsage, "postponed_recovery_compat"
+		}
+	case sntypes.SuperNodeStateActive, sntypes.SuperNodeStateStorageFull:
+		return math.Nextafter(storageFullUsage, 100), "storage_full_compat"
+	}
+
+	return actual, ""
+}
+
+func latestSupernodeState(sn *sntypes.SuperNode) (sntypes.SuperNodeState, string) {
+	if sn == nil || len(sn.States) == 0 {
+		return sntypes.SuperNodeStateUnspecified, ""
+	}
+	for i := len(sn.States) - 1; i >= 0; i-- {
+		if sn.States[i] != nil {
+			return sn.States[i].State, sn.States[i].Reason
+		}
+	}
+	return sntypes.SuperNodeStateUnspecified, ""
 }
 
 func (s *Service) cascadeKademliaDBBytes(_ context.Context) (uint64, bool) {

--- a/supernode/host_reporter/service_test.go
+++ b/supernode/host_reporter/service_test.go
@@ -5,6 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
+	sntypes "github.com/LumeraProtocol/lumera/x/supernode/v1/types"
+	lumeraMock "github.com/LumeraProtocol/supernode/v2/pkg/lumera"
+	supernodemod "github.com/LumeraProtocol/supernode/v2/pkg/lumera/modules/supernode"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNormalizeProbeHost(t *testing.T) {
@@ -66,5 +72,75 @@ func TestCascadeKademliaDBBytes_NoMatches(t *testing.T) {
 	_, ok := s.cascadeKademliaDBBytes(context.Background())
 	if ok {
 		t.Fatalf("expected ok=false when no sqlite db files exist")
+	}
+}
+
+func TestAuditDiskUsagePercentCompat(t *testing.T) {
+	tests := []struct {
+		name       string
+		actual     float64
+		state      sntypes.SuperNodeState
+		reason     string
+		want       float64
+		wantReason string
+	}{
+		{name: "active below audit threshold reports actual", actual: 84.9, state: sntypes.SuperNodeStateActive, want: 84.9},
+		{name: "active at audit threshold reports storage full signal", actual: 85, state: sntypes.SuperNodeStateActive, want: 90.00000000000001, wantReason: "storage_full_compat"},
+		{name: "storage full in overlap stays storage full", actual: 87, state: sntypes.SuperNodeStateStorageFull, want: 90.00000000000001, wantReason: "storage_full_compat"},
+		{name: "postponed host requirements reports recovery value", actual: 88, state: sntypes.SuperNodeStatePostponed, reason: postponeReasonAuditHostRequirements, want: 85, wantReason: "postponed_recovery_compat"},
+		{name: "postponed old no-reason reports recovery value", actual: 88, state: sntypes.SuperNodeStatePostponed, want: 85, wantReason: "postponed_recovery_compat"},
+		{name: "postponed non-host reason reports actual", actual: 88, state: sntypes.SuperNodeStatePostponed, reason: "audit_peer_ports", want: 88},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			auditMod := &stubAuditModule{params: &audittypes.QueryParamsResponse{Params: audittypes.Params{MinDiskFreePercent: 15}}}
+			snMod := supernodemod.NewMockModule(ctrl)
+			client := lumeraMock.NewMockClient(ctrl)
+			client.EXPECT().Audit().Return(auditMod)
+			client.EXPECT().SuperNode().Return(snMod).AnyTimes()
+			snMod.EXPECT().GetParams(gomock.Any()).Return(&sntypes.QueryParamsResponse{Params: sntypes.Params{MaxStorageUsagePercent: 90}}, nil)
+			if tc.wantReason != "" || tc.state == sntypes.SuperNodeStatePostponed {
+				snMod.EXPECT().GetSupernodeBySupernodeAddress(gomock.Any(), "local-sn").Return(&sntypes.SuperNode{
+					SupernodeAccount: "local-sn",
+					States: []*sntypes.SuperNodeStateRecord{{
+						State:  tc.state,
+						Height: 1,
+						Reason: tc.reason,
+					}},
+				}, nil)
+			}
+
+			svc := &Service{identity: "local-sn", lumera: client}
+			got, reason := svc.auditDiskUsagePercent(context.Background(), tc.actual)
+			if got != tc.want {
+				t.Fatalf("reported disk=%v want %v", got, tc.want)
+			}
+			if reason != tc.wantReason {
+				t.Fatalf("reason=%q want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestAuditDiskUsagePercentCompatFailsClosedWhenParamsUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	auditMod := &stubAuditModule{params: &audittypes.QueryParamsResponse{Params: audittypes.Params{MinDiskFreePercent: 0}}}
+	client := lumeraMock.NewMockClient(ctrl)
+	client.EXPECT().Audit().Return(auditMod)
+
+	svc := &Service{identity: "local-sn", lumera: client}
+	got, reason := svc.auditDiskUsagePercent(context.Background(), 88)
+	if got != 88 {
+		t.Fatalf("reported disk=%v want actual", got)
+	}
+	if reason != "" {
+		t.Fatalf("reason=%q want empty", reason)
 	}
 }

--- a/supernode/host_reporter/tick_behavior_test.go
+++ b/supernode/host_reporter/tick_behavior_test.go
@@ -26,11 +26,15 @@ import (
 type stubAuditModule struct {
 	currentEpoch   *audittypes.QueryCurrentEpochResponse
 	anchor         *audittypes.QueryEpochAnchorResponse
+	params         *audittypes.QueryParamsResponse
 	epochReportErr error
 	assigned       *audittypes.QueryAssignedTargetsResponse
 }
 
 func (s *stubAuditModule) GetParams(ctx context.Context) (*audittypes.QueryParamsResponse, error) {
+	if s.params != nil {
+		return s.params, nil
+	}
 	return &audittypes.QueryParamsResponse{}, nil
 }
 func (s *stubAuditModule) GetEpochAnchor(ctx context.Context, epochID uint64) (*audittypes.QueryEpochAnchorResponse, error) {


### PR DESCRIPTION
## Summary

Temporary compatibility patch for the deployed mainnet `v1.12.0` chain behavior where audit host requirements can POSTPONE supernodes in the `85..90%` disk usage band before the audit STORAGE_FULL path can fire.

This patch changes only the audit epoch `HostReport.DiskUsagePercent` submitted by the supernode host reporter. Local REST/status and local disk metrics remain truthful.

Behavior:
- `ACTIVE` / `STORAGE_FULL` with actual disk usage at or above the audit postpone threshold reports a value just above `supernode.max_storage_usage_percent`, forcing the chain's existing audit `SetReport` STORAGE_FULL transition.
- `POSTPONED` with reason `audit_host_requirements` or an old empty reason reports exactly the audit threshold for one recovery epoch, allowing deployed chain recovery rules to move it back to ACTIVE. The next epoch then reports the storage-full signal and moves it to STORAGE_FULL.
- Non-host-requirement POSTPONED nodes are not recovered through this compatibility path.
- If params or current supernode state cannot be queried, the reporter fails closed and sends the actual disk value.

## Invariant Table

| Field / Behavior | Valid Range / Contract | Enforcement Points | Test Coverage |
|---|---|---|---|
| Audit HostReport disk compatibility value | Only audit epoch report disk may be compatibility-mapped; local metrics/status stay actual | `host_reporter.tick` -> `auditDiskUsagePercent`; `audit_msg.SubmitEpochReport` preserves caller disk | `TestAuditDiskUsagePercentCompat`, existing tick tests |
| Already-POSTPONED recovery shim | Only `POSTPONED` with `audit_host_requirements` or legacy empty reason gets one compliant report | `latestSupernodeState`, params overlap check, current state query | `postponed host requirements`, `postponed old no-reason`, `postponed non-host reason` cases |
| Fail-closed behavior | Missing/disabled params or invalid actual disk must not invent data | params checks before override | `TestAuditDiskUsagePercentCompatFailsClosedWhenParamsUnavailable` |

## Tests

- `go test -count=1 ./supernode/host_reporter`
- `go test -count=1 ./supernode/host_reporter ./pkg/lumera/modules/audit_msg ./pkg/lumera/modules/supernode`
- `go test -count=1 ./supernode/...`
- `git diff --check`

## Risk / Rollback

Risk is intentionally scoped to audit epoch HostReport disk reporting. Rollback is reverting this PR or shipping the permanent chain fix so the compatibility mapping is no longer needed.