### PR TITLE
fix(p2p/kademlia): guard handlePing against nil/malformed Sender (panic-safety)

### DIFF
--- a/p2p/kademlia/handle_ping_test.go
+++ b/p2p/kademlia/handle_ping_test.go
@@ -1,0 +1,87 @@
+package kademlia
+
+import (
+	"context"
+	"testing"
+)
+
+// TestHandlePing_NilMessage ensures the request path rejects a nil message
+// without dereferencing it. Regression for the kademlia handlePing nil-sender
+// panic that crashed lumera-devnet-1 val4's supernode process (RCA: a peer
+// sending a Ping with nil Sender caused gob.Encode to walk a nil *Node and
+// SIGSEGV, killing the entire process because no upstream recover() existed).
+func TestHandlePing_NilMessage(t *testing.T) {
+	s := &Network{}
+	res, err := s.handlePing(context.Background(), nil)
+	if err == nil {
+		t.Fatalf("nil message must return error; got res=%v err=nil", res)
+	}
+	if res != nil {
+		t.Fatalf("nil message must return nil response; got %v", res)
+	}
+}
+
+// TestHandlePing_NilSender ensures the request path rejects a Message with no
+// Sender, before invoking dht.newMessage (which would deref the nil pointer).
+func TestHandlePing_NilSender(t *testing.T) {
+	s := &Network{}
+	res, err := s.handlePing(context.Background(), &Message{MessageType: Ping})
+	if err == nil {
+		t.Fatalf("nil sender must return error; got res=%v err=nil", res)
+	}
+	if res != nil {
+		t.Fatalf("nil sender must return nil response; got %v", res)
+	}
+}
+
+// TestHandlePing_EmptySenderID ensures a Sender with empty ID is rejected.
+// gob would happily encode an empty []byte but the encoded Receiver would be
+// a self-reference with no identity — useless and a sanitisation gap.
+func TestHandlePing_EmptySenderID(t *testing.T) {
+	s := &Network{}
+	cases := []struct {
+		name string
+		id   []byte
+	}{
+		{"nil-id", nil},
+		{"empty-slice-id", []byte{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &Message{MessageType: Ping, Sender: &Node{ID: tc.id, IP: "1.2.3.4", Port: 4445}}
+			res, err := s.handlePing(context.Background(), msg)
+			if err == nil {
+				t.Fatalf("empty sender ID must return error; got res=%v err=nil", res)
+			}
+			if res != nil {
+				t.Fatalf("empty sender ID must return nil response; got %v", res)
+			}
+		})
+	}
+}
+
+// TestHandlePing_PanicRecovered constructs a Message that — once it reaches
+// dht.newMessage — would panic because the *Network has no DHT wired up.
+// The deferred recover() in handlePing must turn that panic into an error
+// return, NOT crash the test (which would crash the supernode in production).
+//
+// We satisfy the nil-guard with a valid Sender so the panic comes from the
+// dht.newMessage call (nil *DHT receiver). This is the defence-in-depth
+// layer of the fix: even if a future code path reintroduces a nil deref,
+// the request handler must not kill the process.
+func TestHandlePing_PanicRecovered(t *testing.T) {
+	s := &Network{} // s.dht == nil → newMessage(...) will panic on receiver deref
+	msg := &Message{
+		MessageType: Ping,
+		Sender:      &Node{ID: []byte("peer-id-32-bytes-or-whatever-fits"), IP: "1.2.3.4", Port: 4445},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handlePing leaked a panic to caller: %v", r)
+		}
+	}()
+	res, err := s.handlePing(context.Background(), msg)
+	if err == nil {
+		t.Fatalf("expected error from recovered panic; got res=%v err=nil", res)
+	}
+}

--- a/p2p/kademlia/network.go
+++ b/p2p/kademlia/network.go
@@ -353,11 +353,40 @@ func (s *Network) handleReplicateRequest(ctx context.Context, req *ReplicateData
 	return nil
 }
 
-func (s *Network) handlePing(ctx context.Context, message *Message) ([]byte, error) {
-	// new a response message
-	resMsg := s.dht.newMessage(Ping, message.Sender, nil)
+func (s *Network) handlePing(ctx context.Context, message *Message) (res []byte, err error) {
+	// Recover any panic in the request path so a single malformed Ping cannot
+	// crash the supernode process. See SuperNode RCA (kademlia handlePing nil
+	// sender panic): without this guard, gob.Encode walks a peer-supplied nil
+	// *Node and SIGSEGVs inside encUint8Array, killing the goroutine and (since
+	// there is no upstream recover()) the entire process.
+	defer func() {
+		if r := recover(); r != nil {
+			logtrace.Error(ctx, "handlePing panic recovered", logtrace.Fields{
+				logtrace.FieldModule: "p2p",
+				"panic":              fmt.Sprintf("%v", r),
+			})
+			res, err = nil, errors.New("handlePing: recovered panic")
+		}
+	}()
 
-	go s.dht.addNode(context.Background(), message.Sender)
+	if message == nil || message.Sender == nil || len(message.Sender.ID) == 0 {
+		return nil, errors.New("handlePing: invalid sender")
+	}
+
+	// Sanitize: build our own *Node from the peer-supplied fields so we do not
+	// reflect attacker-controlled HashedID (or any other future field) back on
+	// the wire when we encode the response.
+	sender := &Node{
+		ID:      message.Sender.ID,
+		IP:      message.Sender.IP,
+		Port:    message.Sender.Port,
+		Version: message.Sender.Version,
+	}
+	sender.SetHashedID()
+
+	resMsg := s.dht.newMessage(Ping, sender, nil)
+
+	go s.dht.addNode(context.Background(), sender)
 
 	return s.encodeMesage(resMsg)
 }
@@ -591,8 +620,23 @@ func (s *Network) serve(ctx context.Context) {
 			return
 		}
 
-		// handle the connection requests
-		go s.handleConn(ctx, conn)
+		// handle the connection requests with a top-level recover so a single
+		// malformed peer cannot crash the supernode process. Per-handler
+		// recovers (e.g. handlePing's, handleFindNode's) catch most cases, but
+		// this outer guard is defense-in-depth for any future code path that
+		// forgets to install its own.
+		go func(c net.Conn) {
+			defer func() {
+				if r := recover(); r != nil {
+					logtrace.Error(ctx, "handleConn panic recovered", logtrace.Fields{
+						logtrace.FieldModule: "p2p",
+						"panic":              fmt.Sprintf("%v", r),
+					})
+					_ = c.Close()
+				}
+			}()
+			s.handleConn(ctx, c)
+		}(conn)
 	}
 }
 


### PR DESCRIPTION
# fix(p2p/kademlia): guard `handlePing` against nil/malformed Sender (panic-safety)

## What & why

A peer sending a kademlia Ping with a nil or structurally invalid `Sender` caused `gob.Encode` of the outgoing response to walk a nil pointer and SIGSEGV inside `encoding/gob.encUint8Array`. Because the per-conn goroutine spawned by `serve()` (`p2p/kademlia/network.go:595`) had no upstream `recover()`, and `handlePing` — unlike sibling `handleFindNode` — had no `defer s.handlePanic(...)` of its own, the entire supernode process died.

Observed in production on **`lumera-devnet-1` val4 SN** (goroutine 2067, gob's internal `catchError` repanicked, SIGSEGV addr=0x0). Full RCA: [`kademlia-panic-rca.md`](#).

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
goroutine 2067 [running]:
encoding/gob.(*encBuffer).Write(...)
encoding/gob.encUint8Array(...)
encoding/gob.(*Encoder).encodeStruct(...) x2
…
github.com/LumeraProtocol/supernode/v2/p2p/kademlia.(*Network).handlePing
        github.com/LumeraProtocol/supernode/v2/p2p/kademlia/network.go:362 +0xbf
github.com/LumeraProtocol/supernode/v2/p2p/kademlia.(*Network).handleConn.func4
        github.com/LumeraProtocol/supernode/v2/p2p/kademlia/network.go:473 +0x26
created by …kademlia.(*Network).serve in goroutine 95
        github.com/LumeraProtocol/supernode/v2/p2p/kademlia/network.go:595 +0x105
```

## Fix — two layers, both required

### 1. `handlePing` (`p2p/kademlia/network.go`)
- **Nil-guard** the message, the `Sender` pointer, and `Sender.ID` length. Return an error instead of dereferencing.
- **Sanitise** the peer-supplied `*Node` before reflecting it back on the wire. Specifically, **do not echo `HashedID`** (attacker-controlled) — recompute it locally via `Node.SetHashedID()`, mirroring how `dht.go` constructs every other outgoing Node.
- **Deferred `recover()`** around the whole function: any future panic in this code path becomes an error return rather than process death.

### 2. `serve` loop (`p2p/kademlia/network.go`)
Wrap the bare `go s.handleConn(ctx, conn)` in a top-level recover. Sibling handlers (`handleFindNode`, `handleStoreData`, etc.) already install their own `defer s.handlePanic(...)`, but this is defense-in-depth so any **future** handler that forgets to install its own cannot crash the process either. On recover the connection is closed cleanly.

## Risk

- **Behaviour change only on inputs that previously crashed the process.** Well-formed Pings — both ours and any legitimate peer's — produce byte-identical responses because the sanitised `*Node` is constructed from the same `{ID, IP, Port, Version}` and `SetHashedID()` is the same call already used everywhere else in `dht.go` / `hashtable.go`.
- No public API change.
- No state-machine implication (off-chain SN code).
- Rollback: revert this commit; reverts to v1.12.0 behaviour.

## Mainnet exposure

**HIGH** (potentially CRITICAL pending review of `NewSecureServerConn`). Any peer that can complete one Lumera P2P secure handshake can crash any other SN at will. After restart the same probe repeats — sustained DoS. The "Server secure handshake failed: EOF" WARNs that immediately preceded the crash on val4 indicate the attacker was probing the handshake state machine; the panic fired the moment one probe completed.

## Tests

`p2p/kademlia/handle_ping_test.go`:
- `TestHandlePing_NilMessage` — nil `*Message` returns error.
- `TestHandlePing_NilSender` — Message with no Sender returns error.
- `TestHandlePing_EmptySenderID` — Sender with nil/empty `ID` returns error (table-driven).
- `TestHandlePing_PanicRecovered` — constructs a `*Network` without a `*DHT` so `newMessage` panics on the nil-receiver deref; asserts the deferred `recover()` converts that to an error return rather than letting the panic escape to the caller (which, in production, would have crashed the process).

```
$ go test -count=1 -run TestHandlePing ./p2p/kademlia/
ok  	github.com/LumeraProtocol/supernode/v2/p2p/kademlia	0.045s

$ go test -count=1 -timeout 60s ./p2p/kademlia/...
ok  	github.com/LumeraProtocol/supernode/v2/p2p/kademlia	0.046s
ok  	github.com/LumeraProtocol/supernode/v2/p2p/kademlia/store/meta	0.004s
ok  	github.com/LumeraProtocol/supernode/v2/p2p/kademlia/store/sqlite	9.290s
```

## Follow-ups (NOT in this PR)

- Fuzz target `FuzzDecodeThenDispatch` over `handleConn`'s switch — seed corpus with malformed Sender (empty ID, oversized `HashedID`, registered-interface confusion on `Data`).
- Audit every other `handle*` in `network.go:143–1325` for the same omission pattern (`handleFindNode` etc. all have defers, but worth one targeted pass).
- Confirm secure-handshake authentication actually gates *identity*, not just ciphertext framing — if the handshake completes without binding to a registered SN identity, the attacker prerequisite is "any TCP peer", and severity escalates to CRITICAL.

## Observability

On panic, a structured `logtrace.Error` is emitted with `module=p2p` and the panic value. Datadog query: `service:*supernode* @module:p2p "panic recovered"`.
