### PR TITLE
ci(release): fold deploy-intent check into tag_info step (fix startup failure from #303)

### DIFF
--- a/.github/workflows/build&release.yml
+++ b/.github/workflows/build&release.yml
@@ -72,17 +72,16 @@ jobs:
             echo "GHOEOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Check deploy intent
-        id: deploy_check
-        env:
-          TAG_MSG: ${{ steps.tag_info.outputs.tag_message }}
-        run: |
-          # NOTE: TAG_MSG is passed via env: (not ${{ }} inlined into the script)
-          # because the tag/commit message is multi-line and may contain shell
-          # metacharacters or command names (e.g. "deadcode"). Inlining it would
-          # let those lines execute as bash and abort the release job with exit
-          # 127. See build&release.yml history / v2.6.0-testnet post-mortem.
-          if printf '%s' "$TAG_MSG" | grep -qi '\[no-deploy\]'; then
+          # Deploy-intent check runs HERE (not in a separate step) because
+          # step-level `env:` values cannot safely carry the multi-line
+          # tag_message output — GHA rejects such workflows with a startup
+          # failure (0 jobs, run_attempt=1 completed instantly). Doing the
+          # check inline keeps the raw message inside a bash variable and
+          # only exports the single-line `draft` boolean to downstream steps.
+          # Prior implementation inlined the message via ${{ }} interpolation,
+          # which let commit-body tokens (e.g. "deadcode") execute as bash
+          # and killed v2.6.0-testnet with exit 127. See PR history.
+          if printf '%s' "$TAG_MESSAGE" | grep -qi '\[no-deploy\]'; then
             echo "draft=true" >> "$GITHUB_OUTPUT"
             echo "⚠️  [no-deploy] detected — release will be created as DRAFT"
           else
@@ -222,7 +221,7 @@ jobs:
         if: success() && steps.rel_check.outputs.exists != 'true'
         with:
           tag_name: ${{ steps.tag_info.outputs.tag_name }}
-          draft: ${{ steps.deploy_check.outputs.draft == 'true' }}
+          draft: ${{ steps.tag_info.outputs.draft == 'true' }}
           files: |
             release/${{ steps.vars.outputs.binary_name }}.tar.gz
             release/${{ steps.vars.outputs.binary_name }}
@@ -234,7 +233,7 @@ jobs:
         if: success() && steps.rel_check.outputs.exists == 'true'
         with:
           tag_name: ${{ steps.tag_info.outputs.tag_name }}
-          draft: ${{ steps.deploy_check.outputs.draft == 'true' }}
+          draft: ${{ steps.tag_info.outputs.draft == 'true' }}
           files: |
             release/${{ steps.vars.outputs.binary_name }}.tar.gz
             release/${{ steps.vars.outputs.binary_name }}


### PR DESCRIPTION
## Summary

Follow-up to #303. That PR moved the tag-message into a step-level `env:` block to avoid shell-expanding a multi-line value into `run:`. Unfortunately GHA rejects that shape at **workflow dispatch time** — a multi-line output cannot be plumbed into another step's `env:` — so the `release` job never got scheduled.

## Evidence the previous fix failed to run

Runs on the post-merge master SHA `8eae29e` (Build and Release Workflow, id `163702778`):

- `28627254564` — status `completed`, conclusion `failure`, **jobs=[]**, `run_started_at == updated_at` (dispatched and closed in the same second)
- `28627293599` — same signature
- Same signature on the fix branch push at `28615651344`

This is the classic GHA startup-failure fingerprint: the workflow file **parses**, but the job graph is refused at scheduling.

## Fix

Perform the `[no-deploy]` grep **inside the `Get tag information` step**, where `$TAG_MESSAGE` already exists as a plain bash variable, and export the single-line `draft` boolean from the same step. The multi-line `tag_message` output is still emitted (the release-body heredoc consumes it via `<<'EOT'`, which is safe).

Two downstream references are updated from `steps.deploy_check.outputs.draft` → `steps.tag_info.outputs.draft`.

## Why this is safer than #303

- No cross-step propagation of multi-line untrusted content.
- No step-level `env:` binding to a multi-line output (which is what tripped the scheduler).
- The `[no-deploy]` semantics are byte-identical (same case-insensitive grep).
- The `draft` output is a fixed `true`/`false` string — always single-line, always safe to consume via `${{ }}`.
- Diff: **12 additions, 13 deletions**, one file.

## Blast radius

- `.github/workflows/build&release.yml` only.
- No change to the actual build, ldflags, artifact naming, tarball layout, `softprops/action-gh-release` step, or release-body composition.
- `release-body` heredoc (line ~208) still uses `<<'EOT'` and continues to reference `steps.tag_info.outputs.tag_message` safely (quoted heredoc suppresses expansion — this was true before and remains true).

## Verification

- Local: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build&release.yml'))"` → OK, jobs `['build', 'release']`.
- Runtime: after merge, will retag `v2.6.0-testnet` at the new master HEAD and confirm CI produces a completed `release` job with `supernode-linux-amd64.tar.gz` + `supernode-linux-amd64` attached to the existing release.

## Rollback

Revert the commit. No state involved.

## Post-merge plan

1. Confirm this PR merges cleanly.
2. Force-retag `v2.6.0-testnet` at new master → CI's `Upload assets to existing release` path attaches the two artifacts to the existing release (preserving the release notes).
3. Run `./testnet_version_check.sh` on the fleet to verify `sn-manager` picks it up on the 15 healthy SNs.
