### PR TITLE
ci(release): remove empty ${{ }} expression from bash comment

### DIFF
--- a/.github/workflows/build&release.yml
+++ b/.github/workflows/build&release.yml
@@ -78,9 +78,10 @@ jobs:
           # failure (0 jobs, run_attempt=1 completed instantly). Doing the
           # check inline keeps the raw message inside a bash variable and
           # only exports the single-line `draft` boolean to downstream steps.
-          # Prior implementation inlined the message via ${{ }} interpolation,
-          # which let commit-body tokens (e.g. "deadcode") execute as bash
-          # and killed v2.6.0-testnet with exit 127. See PR history.
+          # Prior implementation inlined the message via GitHub Actions
+          # expression interpolation, which let commit-body tokens (e.g.
+          # "deadcode") execute as bash and killed v2.6.0-testnet with
+          # exit 127. See PR history (#303 / #307).
           if printf '%s' "$TAG_MESSAGE" | grep -qi '\[no-deploy\]'; then
             echo "draft=true" >> "$GITHUB_OUTPUT"
             echo "⚠️  [no-deploy] detected — release will be created as DRAFT"


### PR DESCRIPTION
## Problem

Every workflow run of `Build and Release Workflow` on master since #307 landed (commit `ea1a9c4`) has been dying at dispatch with the **workflow startup-failure fingerprint** documented in that same PR — `status: completed`, `conclusion: failure`, `jobs: []`, `run_started_at == updated_at` (sub-second), workflow name reported as the raw file path rather than the `name:` field.

Verified on:
- Run [`28756586178`](https://github.com/LumeraProtocol/supernode/actions/runs/28756586178) — push on master @ ea1a9c4
- Run [`28756630521`](https://github.com/LumeraProtocol/supernode/actions/runs/28756630521) — push on master @ ea1a9c4
- Tag push of `v2.6.0-testnet` (retagged onto ea1a9c4 today) never scheduled its release job either — same root cause.

## Root cause

The comment PR #307 added inside the `Get tag information` step's `run:` block contains the literal string:

```
# Prior implementation inlined the message via ${…{ }} interpolation,
```

(showing here with a ZWSP to avoid re-triggering the bug in the PR body.)

GitHub Actions validates every ``${{ … }}`` expression in the workflow file at **dispatch time — including expressions inside bash comments in `run:` block scalars**. It does not know or care that bash would treat the line as a comment; the GHA templating engine parses the whole YAML file first. An empty ``${{ }}`` expression is a syntactic error, so the workflow is rejected before any job is scheduled.

This is the same class of trap as #303 → #307, just at the *comment* layer rather than the *bash-execution* layer.

## Fix

Rephrase the comment to describe the prior pattern in English instead of embedding the literal ``${{ … }}`` syntax. No functional change to any step logic.

```diff
-          # Prior implementation inlined the message via \${{ }} interpolation,
-          # which let commit-body tokens (e.g. \"deadcode\") execute as bash
-          # and killed v2.6.0-testnet with exit 127. See PR history.
+          # Prior implementation inlined the message via GitHub Actions
+          # expression interpolation, which let commit-body tokens (e.g.
+          # \"deadcode\") execute as bash and killed v2.6.0-testnet with
+          # exit 127. See PR history (#303 / #307).
```

## Verification

Pre-merge on the branch commit `1a36fc8`:
- Run [`28756743275`](https://github.com/LumeraProtocol/supernode/actions/runs/28756743275) — `Build and Release Workflow` (correct `name:`, not the raw file path), \`build\` job dispatched (\`in_progress\`), \`release\` job \`skipped\` because branch push doesn't match \`refs/tags/v*\`. Startup-failure fingerprint is gone.

## Next step (not part of this PR)

Once merged, retag \`v2.6.0-testnet\` onto post-merge master. The workflow's \`Check if release already exists\` step will hit the pre-existing draft release object and take the idempotent \"Upload assets to existing release (preserve manual notes)\" path, finally attaching the tarball + binary that the fleet's sn-manager needs.

## Risk / rollback

Comment-only diff. Rollback = revert. No behavioural surface.